### PR TITLE
Add pro options

### DIFF
--- a/frontblocks.php
+++ b/frontblocks.php
@@ -3,7 +3,7 @@
  * Plugin Name: FrontBlocks for GeneratePress
  * Plugin URI:  https://wordpress.org/plugins/frontblocks/
  * Description: Blocks and helpers that extends GeneratePress blocks.
- * Version:     1.0.4
+ * Version:     1.0.5
  * Author:      Closemarketing
  * Author URI:  https://close.marketing
  * Text Domain: frontblocks
@@ -26,7 +26,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'FRBL_VERSION', '1.0.4' );
+define( 'FRBL_VERSION', '1.0.5' );
 define( 'FRBL_PLUGIN', __FILE__ );
 define( 'FRBL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'FRBL_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
@@ -39,3 +39,12 @@ if ( file_exists( FRBL_PLUGIN_PATH . 'vendor/autoload.php' ) ) {
 require_once FRBL_PLUGIN_PATH . 'includes/Plugin_Main.php';
 // Initialize the plugin.
 FrontBlocks\Plugin_Main::get_instance();
+
+/**
+ * Check if FrontBlocks PRO is active.
+ *
+ * @return bool
+ */
+function frbl_is_pro_active() {
+	return defined( 'FRBLP_PRO_ACTIVE' ) && FRBLP_PRO_ACTIVE;
+}

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -87,6 +87,58 @@ class Settings {
 			$this->page_slug,
 			'frontblocks_section_features'
 		);
+
+		if ( ! frbl_is_pro_active() ) {
+			add_settings_section(
+				'frontblocks_section_woocommerce_features',
+				__( 'WooCommerce Features', 'frontblocks' ),
+				function () {
+					echo '<p>' . esc_html__( 'WooCommerce FrontBlocks PRO is a premium plugin that adds more features to WooCommerce FrontBlocks. Customize your WooCommerce store with more features.', 'frontblocks' ) . '</p>';
+					echo '<p><a href="https://close.technology/wordpress-plugins/front-blocks-pro/?ref=WordPressPlugin" target="_blank" class="button button-secondary">' . esc_html__( 'Buy WooCommerce FrontBlocks PRO', 'frontblocks' ) . '</a></p>';
+				},
+				$this->page_slug
+			);
+		}
+
+		do_action( 'frontblocks_register_settings' );
+	}
+
+	/**
+	 * Render settings page.
+	 *
+	 * @return void
+	 */
+	public function render_page() {
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return;
+		}
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html__( 'Frontblocks Settings', 'frontblocks' ); ?></h1>
+
+			<form method="post" action="options.php" style="margin-top:20px;">
+				<?php
+				settings_fields( 'frontblocks_settings' );
+				do_settings_sections( $this->page_slug );
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render checkbox field for enable testimonials.
+	 *
+	 * @return void
+	 */
+	public function field_enable_testimonials() {
+		$options = get_option( 'frontblocks_settings', array() );
+		$enabled = (bool) ( $options[ $this->option_enable_testimonials ] ?? false );
+		echo '<label for="' . esc_attr( $this->option_enable_testimonials ) . '">';
+		echo '<input type="checkbox" id="' . esc_attr( $this->option_enable_testimonials ) . '" name="frontblocks_settings[' . esc_attr( $this->option_enable_testimonials ) . ']" value="1" ' . checked( true, $enabled, false ) . ' /> ';
+		echo esc_html__( 'Enable testimonials', 'frontblocks' );
+		echo '</label>';
 	}
 
 	/**
@@ -110,44 +162,5 @@ class Settings {
 		}
 
 		return $sanitized;
-	}
-
-	/**
-	 * Render checkbox field for enable testimonials.
-	 *
-	 * @return void
-	 */
-	public function field_enable_testimonials() {
-		$options = get_option( 'frontblocks_settings', array() );
-		$enabled = (bool) ( $options[ $this->option_enable_testimonials ] ?? false );
-		echo '<label for="' . esc_attr( $this->option_enable_testimonials ) . '">';
-		echo '<input type="checkbox" id="' . esc_attr( $this->option_enable_testimonials ) . '" name="frontblocks_settings[' . esc_attr( $this->option_enable_testimonials ) . ']" value="1" ' . checked( true, $enabled, false ) . ' /> ';
-		echo esc_html__( 'Enable testimonials', 'frontblocks' );
-		echo '</label>';
-	}
-
-	/**
-	 * Render settings page.
-	 *
-	 * @return void
-	 */
-	public function render_page() {
-		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			return;
-		}
-		?>
-		<div class="wrap">
-				<h1><?php echo esc_html__( 'Frontblocks Settings', 'frontblocks' ); ?></h1>
-			</div>
-
-			<form method="post" action="options.php" style="margin-top:20px;">
-				<?php
-				settings_fields( 'frontblocks_settings' );
-				do_settings_sections( $this->page_slug );
-				submit_button();
-				?>
-			</form>
-		</div>
-		<?php
 	}
 }

--- a/includes/Plugin_Main.php
+++ b/includes/Plugin_Main.php
@@ -39,6 +39,15 @@ class Plugin_Main {
 	}
 
 	/**
+	 * Check if FrontBlocks PRO is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_pro_active() {
+		return defined( 'FRBLP_PRO_ACTIVE' ) && FRBLP_PRO_ACTIVE;
+	}
+
+	/**
 	 * Constructor.
 	 */
 	private function __construct() {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 parameters:
     level: 1
     paths:
+        - frontblocks.php
         - includes
     bootstrapFiles:
         - tests/phpstan-bootstrap.php

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,11 @@ Display testimonials from other posts, pages, or custom post types. Search and s
 
 Shortcode: [frontblocks_testimonials_carousel]
 
+**WooCommerce Features:**
+Included features for WooCommerce FrontBlocks PRO:
+
+More information in the [FrontBlocks PRO](https://close.technology/wordpress-plugins/front-blocks-pro/?ref=WordPressPlugin) page.
+
 Others Plugins:
 - [Closemarketing Plugins](https://profiles.wordpress.org/closemarketing/#content-plugins)
 
@@ -85,6 +90,9 @@ WordPress installation and then activate the Plugin from Plugins page.
 [Official Repository Github](https://github.com/closemarketing/frontblocks)
 
 == Changelog ==
+
+= 1.0.5 =
+*   Added: FrontBlocks PRO compatibility.
 
 = 1.0.4 =
 *   Added: Product Categories block.


### PR DESCRIPTION
## Summary

Added FrontBlocks PRO compatibility: introduced a helper function to detect if the PRO plugin is active and added a WooCommerce features section to the settings page.

- Added `frbl_is_pro_active()` global function in `frontblocks.php` (checks for `FRBLP_PRO_ACTIVE` constant)
- Added a static `Plugin_Main::is_pro_active()` method (same logic)
- Added a "WooCommerce Features" settings section for non-PRO installations with an upsell message and purchase link
- Added `do_action( 'frontblocks_register_settings' )` hook so PRO can register its own settings fields
- Refactored `Settings::render_page()` and `sanitize_settings()` layout/ordering
- Bumped version to `1.0.5` and updated changelog in `readme.txt`