### PR TITLE
Add item to view in laptop and tablet

### DIFF
--- a/assets/carousel/frontblocks-advanced-option.js
+++ b/assets/carousel/frontblocks-advanced-option.js
@@ -31,18 +31,22 @@ function addCustomCarouselPanel(BlockEdit) {
       frblGridOption = _props$attributes$frb === void 0 ? 'none' : _props$attributes$frb,
       _props$attributes$frb2 = _props$attributes.frblItemsToView,
       frblItemsToView = _props$attributes$frb2 === void 0 ? '4' : _props$attributes$frb2,
-      _props$attributes$frb3 = _props$attributes.frblResponsiveToView,
-      frblResponsiveToView = _props$attributes$frb3 === void 0 ? '1' : _props$attributes$frb3,
-      _props$attributes$frb4 = _props$attributes.frblAutoplay,
-      frblAutoplay = _props$attributes$frb4 === void 0 ? '' : _props$attributes$frb4,
-      _props$attributes$frb5 = _props$attributes.frblButtons,
-      frblButtons = _props$attributes$frb5 === void 0 ? 'arrows' : _props$attributes$frb5,
-      _props$attributes$frb6 = _props$attributes.frblRewind,
-      frblRewind = _props$attributes$frb6 === void 0 ? true : _props$attributes$frb6,
+      _props$attributes$frb3 = _props$attributes.frblLaptopToView,
+      frblLaptopToView = _props$attributes$frb3 === void 0 ? '3' : _props$attributes$frb3,
+      _props$attributes$frb4 = _props$attributes.frblTabletToView,
+      frblTabletToView = _props$attributes$frb4 === void 0 ? '2' : _props$attributes$frb4,
+      _props$attributes$frb5 = _props$attributes.frblResponsiveToView,
+      frblResponsiveToView = _props$attributes$frb5 === void 0 ? '1' : _props$attributes$frb5,
+      _props$attributes$frb6 = _props$attributes.frblAutoplay,
+      frblAutoplay = _props$attributes$frb6 === void 0 ? '' : _props$attributes$frb6,
+      _props$attributes$frb7 = _props$attributes.frblButtons,
+      frblButtons = _props$attributes$frb7 === void 0 ? 'arrows' : _props$attributes$frb7,
+      _props$attributes$frb8 = _props$attributes.frblRewind,
+      frblRewind = _props$attributes$frb8 === void 0 ? true : _props$attributes$frb8,
       frblButtonColor = _props$attributes.frblButtonColor,
       frblButtonBgColor = _props$attributes.frblButtonBgColor,
-      _props$attributes$frb7 = _props$attributes.frblButtonsPosition,
-      frblButtonsPosition = _props$attributes$frb7 === void 0 ? 'side' : _props$attributes$frb7;
+      _props$attributes$frb9 = _props$attributes.frblButtonsPosition,
+      frblButtonsPosition = _props$attributes$frb9 === void 0 ? 'side' : _props$attributes$frb9;
     return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(BlockEdit, props), /*#__PURE__*/React.createElement(InspectorControls, null, /*#__PURE__*/React.createElement(PanelBody, {
       title: __('Carousel Settings', 'frontblocks'),
       initialOpen: true
@@ -66,21 +70,41 @@ function addCustomCarouselPanel(BlockEdit) {
       },
       help: __('This option gives the option to make carousel in your grid block.', 'frontblocks')
     }), frblGridOption !== 'none' && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(TextControl, {
-      label: __('Items to view', 'frontblocks'),
+      label: __('Items to view (Desktop)', 'frontblocks'),
       value: frblItemsToView,
       onChange: function onChange(value) {
         return props.setAttributes({
           frblItemsToView: value
         });
-      }
+      },
+      help: __('Number of items visible on desktop (>1440px)', 'frontblocks')
     }), /*#__PURE__*/React.createElement(TextControl, {
-      label: __('Responsive to view', 'frontblocks'),
+      label: __('Items to view (Laptop)', 'frontblocks'),
+      value: frblLaptopToView,
+      onChange: function onChange(value) {
+        return props.setAttributes({
+          frblLaptopToView: value
+        });
+      },
+      help: __('Number of items visible on laptop (1025px-1440px)', 'frontblocks')
+    }), /*#__PURE__*/React.createElement(TextControl, {
+      label: __('Items to view (Tablet)', 'frontblocks'),
+      value: frblTabletToView,
+      onChange: function onChange(value) {
+        return props.setAttributes({
+          frblTabletToView: value
+        });
+      },
+      help: __('Number of items visible on tablet (769px-1024px)', 'frontblocks')
+    }), /*#__PURE__*/React.createElement(TextControl, {
+      label: __('Items to view (Mobile)', 'frontblocks'),
       value: frblResponsiveToView,
       onChange: function onChange(value) {
         return props.setAttributes({
           frblResponsiveToView: value
         });
-      }
+      },
+      help: __('Number of items visible on mobile (≤768px)', 'frontblocks')
     }), /*#__PURE__*/React.createElement(TextControl, {
       label: __('Autoplay (seconds)', 'frontblocks'),
       value: frblAutoplay,

--- a/assets/carousel/frontblocks-advanced-option.jsx
+++ b/assets/carousel/frontblocks-advanced-option.jsx
@@ -20,17 +20,19 @@ function addCustomCarouselPanel(BlockEdit) {
 			}
 		}
 
-		const {
-				frblGridOption = 'none',
-				frblItemsToView = '4',
-				frblResponsiveToView = '1',
-				frblAutoplay = '',
-				frblButtons = 'arrows',
-				frblRewind = true,
-				frblButtonColor,
-				frblButtonBgColor,
-				frblButtonsPosition = 'side',
-		} = props.attributes;
+	const {
+			frblGridOption = 'none',
+			frblItemsToView = '4',
+			frblLaptopToView = '3',
+			frblTabletToView = '2',
+			frblResponsiveToView = '1',
+			frblAutoplay = '',
+			frblButtons = 'arrows',
+			frblRewind = true,
+			frblButtonColor,
+			frblButtonBgColor,
+			frblButtonsPosition = 'side',
+	} = props.attributes;
 
 		return (
 			<Fragment>
@@ -56,14 +58,28 @@ function addCustomCarouselPanel(BlockEdit) {
 						{frblGridOption !== 'none' && (
 							<>
 								<TextControl
-									label={__('Items to view', 'frontblocks')}
+									label={__('Items to view (Desktop)', 'frontblocks')}
 									value={frblItemsToView}
 									onChange={(value) => props.setAttributes({ frblItemsToView: value })}
+									help={__('Number of items visible on desktop (>1440px)', 'frontblocks')}
 								/>
 								<TextControl
-									label={__('Responsive to view', 'frontblocks')}
+									label={__('Items to view (Laptop)', 'frontblocks')}
+									value={frblLaptopToView}
+									onChange={(value) => props.setAttributes({ frblLaptopToView: value })}
+									help={__('Number of items visible on laptop (1025px-1440px)', 'frontblocks')}
+								/>
+								<TextControl
+									label={__('Items to view (Tablet)', 'frontblocks')}
+									value={frblTabletToView}
+									onChange={(value) => props.setAttributes({ frblTabletToView: value })}
+									help={__('Number of items visible on tablet (769px-1024px)', 'frontblocks')}
+								/>
+								<TextControl
+									label={__('Items to view (Mobile)', 'frontblocks')}
 									value={frblResponsiveToView}
 									onChange={(value) => props.setAttributes({ frblResponsiveToView: value })}
+									help={__('Number of items visible on mobile (≤768px)', 'frontblocks')}
 								/>
 								<TextControl
 									label={__('Autoplay (seconds)', 'frontblocks')}

--- a/assets/carousel/frontblocks-carousel.js
+++ b/assets/carousel/frontblocks-carousel.js
@@ -24,9 +24,11 @@ window.addEventListener('load', function (event) {
             // Options
             const carouselType = item.getAttribute('data-type') ? item.getAttribute('data-type') : 'carousel';
             const carouselbuttons = item.getAttribute('data-buttons') ? item.getAttribute('data-buttons') : 'bullets';
-            const carouselView = item.getAttribute('data-view') ? item.getAttribute('data-view') : 4;
+            const carouselView = item.getAttribute('data-view') ? parseInt(item.getAttribute('data-view')) : 4;
+            const carouselLaptopView = item.getAttribute('data-laptop-view') ? parseInt(item.getAttribute('data-laptop-view')) : 3;
+            const carouselTabletView = item.getAttribute('data-tablet-view') ? parseInt(item.getAttribute('data-tablet-view')) : 2;
+            const carouselMobileView = item.getAttribute('data-mobile-view') ? parseInt(item.getAttribute('data-mobile-view')) : 1;
             const carouselAutoplay = item.getAttribute('data-autoplay') ? item.getAttribute('data-autoplay') : 0;
-            const carouselResView = item.getAttribute('data-res-view') ? item.getAttribute('data-res-view') : 1;
             const carouselRewind = item.getAttribute('data-rewind') ? item.getAttribute('data-rewind') : false;
             const carouselbuttonsColor = item.getAttribute('data-buttons-color') ? item.getAttribute('data-buttons-color') : 'black';
             const carouselbuttonsBackgroundColor = item.getAttribute('data-buttons-background-color') ? item.getAttribute('data-buttons-background-color') : 'transparent';
@@ -103,15 +105,15 @@ window.addEventListener('load', function (event) {
                 gap: 20,
                 rewind: carouselRewind,
                 breakpoints: {
-                    430: {
-                        perView: carouselResView
-                    },
-                    600: {
-                        perView: carouselResView
-                    },
                     768: {
-                        perView: carouselResView
+                        perView: carouselMobileView
                     },
+                    1024: {
+                        perView: carouselTabletView
+                    },
+                    1440: {
+                        perView: carouselLaptopView
+                    }
                 }
             });
 

--- a/includes/Frontend/Carousel.php
+++ b/includes/Frontend/Carousel.php
@@ -64,6 +64,8 @@ class Carousel {
 		$attrs              = $block['attrs'] ?? array();
 		$custom_option      = isset( $attrs['frblGridOption'] ) ? sanitize_text_field( $attrs['frblGridOption'] ) : '';
 		$items_to_view      = isset( $attrs['frblItemsToView'] ) ? (int) $attrs['frblItemsToView'] : 4;
+		$laptop_to_view     = isset( $attrs['frblLaptopToView'] ) ? (int) $attrs['frblLaptopToView'] : 3;
+		$tablet_to_view     = isset( $attrs['frblTabletToView'] ) ? (int) $attrs['frblTabletToView'] : 2;
 		$responsive_to_view = isset( $attrs['frblResponsiveToView'] ) ? (int) $attrs['frblResponsiveToView'] : 1;
 		$autoplay           = isset( $attrs['frblAutoplay'] ) ? ( (int) $attrs['frblAutoplay'] * 1000 ) : '';
 		$rewind             = isset( $attrs['frblRewind'] ) ? (bool) $attrs['frblRewind'] : true;
@@ -85,7 +87,9 @@ class Carousel {
 				'<div$1class="$2 frontblocks-carousel"$3' .
 					' data-type="' . esc_attr( $custom_option ) . '"' .
 					' data-view="' . esc_attr( $items_to_view ) . '"' .
-					' data-res-view="' . esc_attr( $responsive_to_view ) . '"' .
+					' data-laptop-view="' . esc_attr( $laptop_to_view ) . '"' .
+					' data-tablet-view="' . esc_attr( $tablet_to_view ) . '"' .
+					' data-mobile-view="' . esc_attr( $responsive_to_view ) . '"' .
 					' data-autoplay="' . esc_attr( $autoplay ) . '"' .
 					' data-buttons="' . esc_attr( $buttons ) . '"' .
 					' data-buttons-color="' . esc_attr( $button_color ) . '"' .
@@ -122,6 +126,8 @@ class Carousel {
 
 		$custom_option      = isset( $attrs['frblGridOption'] ) ? sanitize_text_field( $attrs['frblGridOption'] ) : '';
 		$items_to_view      = isset( $attrs['frblItemsToView'] ) ? (int) $attrs['frblItemsToView'] : 4;
+		$laptop_to_view     = isset( $attrs['frblLaptopToView'] ) ? (int) $attrs['frblLaptopToView'] : 3;
+		$tablet_to_view     = isset( $attrs['frblTabletToView'] ) ? (int) $attrs['frblTabletToView'] : 2;
 		$responsive_to_view = isset( $attrs['frblResponsiveToView'] ) ? (int) $attrs['frblResponsiveToView'] : 1;
 		$autoplay           = isset( $attrs['frblAutoplay'] ) ? ( (int) $attrs['frblAutoplay'] * 1000 ) : '';
 		$rewind             = isset( $attrs['frblRewind'] ) ? (bool) $attrs['frblRewind'] : true;
@@ -143,7 +149,9 @@ class Carousel {
 				'<div$1class="$2 frontblocks-carousel"$3' .
 					' data-type="' . esc_attr( $custom_option ) . '"' .
 					' data-view="' . esc_attr( $items_to_view ) . '"' .
-					' data-res-view="' . esc_attr( $responsive_to_view ) . '"' .
+					' data-laptop-view="' . esc_attr( $laptop_to_view ) . '"' .
+					' data-tablet-view="' . esc_attr( $tablet_to_view ) . '"' .
+					' data-mobile-view="' . esc_attr( $responsive_to_view ) . '"' .
 					' data-autoplay="' . esc_attr( $autoplay ) . '"' .
 					' data-buttons="' . esc_attr( $buttons ) . '"' .
 					' data-buttons-color="' . esc_attr( $button_color ) . '"' .
@@ -199,6 +207,14 @@ class Carousel {
 		$block_args['attributes']['frblItemsToView']      = array(
 			'type'    => 'string',
 			'default' => '4',
+		);
+		$block_args['attributes']['frblLaptopToView']     = array(
+			'type'    => 'string',
+			'default' => '3',
+		);
+		$block_args['attributes']['frblTabletToView']     = array(
+			'type'    => 'string',
+			'default' => '2',
 		);
 		$block_args['attributes']['frblResponsiveToView'] = array(
 			'type'    => 'string',
@@ -258,6 +274,14 @@ class Carousel {
 						frblItemsToView: {
 							type: 'string',
 							default: '4'
+						},
+						frblLaptopToView: {
+							type: 'string',
+							default: '3'
+						},
+						frblTabletToView: {
+							type: 'string',
+							default: '2'
 						},
 						frblResponsiveToView: {
 							type: 'string',


### PR DESCRIPTION
## Summary

Added laptop and tablet breakpoint controls to the carousel editor panel.

- Added `frblLaptopToView` (default: 3, 1025px–1440px) and `frblTabletToView` (default: 2, 769px–1024px) attributes
- Updated editor UI to show four separate text controls: Desktop (>1440px), Laptop, Tablet, and Mobile (≤768px), each with a help text showing the breakpoint range
- Renamed "Responsive to view" label to "Items to view (Mobile)" and "Items to view" to "Items to view (Desktop)"
- Updated the PHP block renderer to pass `data-laptop-view` and `data-tablet-view` HTML attributes instead of the single `data-res-view`
- Updated the frontend JS initializer to read the three breakpoint attributes and configure Glide.js at 768/1024/1440px breakpoints
- Fixed `carouselView` to use `parseInt()` for correct numeric comparison