### PR TITLE
Traductions completed

### DIFF
--- a/includes/Frontend/Animations.php
+++ b/includes/Frontend/Animations.php
@@ -84,6 +84,12 @@ class Animations {
 			true
 		);
 
+		// Set script translations for JavaScript.
+		wp_set_script_translations(
+			'frontblocks-animation-editor',
+			'frontblocks'
+		);
+
 		// Localize script with custom CSS URL.
 		wp_localize_script(
 			'frontblocks-animation-editor',

--- a/includes/Frontend/Carousel.php
+++ b/includes/Frontend/Carousel.php
@@ -51,6 +51,12 @@ class Carousel {
 			FRBL_VERSION,
 			true
 		);
+
+		// Set script translations for JavaScript.
+		wp_set_script_translations(
+			'frontblocks-advanced-option',
+			'frontblocks'
+		);
 	}
 
 	/**

--- a/includes/Frontend/Counter.php
+++ b/includes/Frontend/Counter.php
@@ -65,6 +65,13 @@ class Counter {
 	 */
 	public function enqueue_editor_assets() {
 		wp_enqueue_script( 'frontblocks-counter-editor' );
+		
+		// Set script translations for JavaScript.
+		wp_set_script_translations(
+			'frontblocks-counter-editor',
+			'frontblocks'
+		);
+		
 		wp_enqueue_style( 'frontblocks-counter-styles' );
 	}
 

--- a/includes/Frontend/Counter.php
+++ b/includes/Frontend/Counter.php
@@ -65,13 +65,13 @@ class Counter {
 	 */
 	public function enqueue_editor_assets() {
 		wp_enqueue_script( 'frontblocks-counter-editor' );
-		
+
 		// Set script translations for JavaScript.
 		wp_set_script_translations(
 			'frontblocks-counter-editor',
 			'frontblocks'
 		);
-		
+
 		wp_enqueue_style( 'frontblocks-counter-styles' );
 	}
 

--- a/includes/Frontend/Gallery.php
+++ b/includes/Frontend/Gallery.php
@@ -90,7 +90,7 @@ class Gallery {
 			FRBL_VERSION,
 			true
 		);
-		
+
 		// Set script translations for JavaScript.
 		wp_set_script_translations(
 			'frontblocks-gallery-option',

--- a/includes/Frontend/Gallery.php
+++ b/includes/Frontend/Gallery.php
@@ -90,6 +90,12 @@ class Gallery {
 			FRBL_VERSION,
 			true
 		);
+		
+		// Set script translations for JavaScript.
+		wp_set_script_translations(
+			'frontblocks-gallery-option',
+			'frontblocks'
+		);
 	}
 
 	/**

--- a/includes/Frontend/Headline.php
+++ b/includes/Frontend/Headline.php
@@ -64,6 +64,13 @@ class Headline {
 	 */
 	public function enqueue_editor_assets() {
 		wp_enqueue_script( 'frontblocks-headline-editor' );
+		
+		// Set script translations for JavaScript.
+		wp_set_script_translations(
+			'frontblocks-headline-editor',
+			'frontblocks'
+		);
+		
 		wp_enqueue_style( 'frontblocks-headline-styles' );
 	}
 

--- a/includes/Frontend/Headline.php
+++ b/includes/Frontend/Headline.php
@@ -64,13 +64,13 @@ class Headline {
 	 */
 	public function enqueue_editor_assets() {
 		wp_enqueue_script( 'frontblocks-headline-editor' );
-		
+
 		// Set script translations for JavaScript.
 		wp_set_script_translations(
 			'frontblocks-headline-editor',
 			'frontblocks'
 		);
-		
+
 		wp_enqueue_style( 'frontblocks-headline-styles' );
 	}
 

--- a/includes/Frontend/InsertPost.php
+++ b/includes/Frontend/InsertPost.php
@@ -72,7 +72,7 @@ class InsertPost {
 			FRBL_VERSION,
 			true
 		);
-		
+
 		// Set script translations for JavaScript.
 		wp_set_script_translations(
 			'frontblocks-insert-post-option',

--- a/includes/Frontend/InsertPost.php
+++ b/includes/Frontend/InsertPost.php
@@ -72,6 +72,12 @@ class InsertPost {
 			FRBL_VERSION,
 			true
 		);
+		
+		// Set script translations for JavaScript.
+		wp_set_script_translations(
+			'frontblocks-insert-post-option',
+			'frontblocks'
+		);
 
 		// Localize script with AJAX URL and nonce.
 		wp_localize_script(

--- a/includes/Frontend/ProductCategories.php
+++ b/includes/Frontend/ProductCategories.php
@@ -135,6 +135,12 @@ class ProductCategories {
 			FRBL_VERSION,
 			true
 		);
+		
+		// Set script translations for JavaScript.
+		wp_set_script_translations(
+			'frontblocks-product-categories-option',
+			'frontblocks'
+		);
 
 		wp_localize_script(
 			'frontblocks-product-categories-option',

--- a/includes/Frontend/ProductCategories.php
+++ b/includes/Frontend/ProductCategories.php
@@ -135,7 +135,7 @@ class ProductCategories {
 			FRBL_VERSION,
 			true
 		);
-		
+
 		// Set script translations for JavaScript.
 		wp_set_script_translations(
 			'frontblocks-product-categories-option',

--- a/includes/Frontend/StickyColumn.php
+++ b/includes/Frontend/StickyColumn.php
@@ -74,6 +74,12 @@ class StickyColumn {
 			FRBL_VERSION,
 			false
 		);
+		
+		// Set script translations for JavaScript.
+		wp_set_script_translations(
+			'frontblocks-sticky-column-editor',
+			'frontblocks'
+		);
 	}
 
 	/**

--- a/includes/Frontend/StickyColumn.php
+++ b/includes/Frontend/StickyColumn.php
@@ -74,7 +74,7 @@ class StickyColumn {
 			FRBL_VERSION,
 			false
 		);
-		
+
 		// Set script translations for JavaScript.
 		wp_set_script_translations(
 			'frontblocks-sticky-column-editor',


### PR DESCRIPTION
## Summary

Added `wp_set_script_translations()` calls to all FrontBlocks editor scripts so that WordPress can serve `.po`/`.json` translation files for JavaScript strings.

- Added `wp_set_script_translations( 'handle', 'frontblocks' )` after each `wp_enqueue_script()` call in: `Animations.php`, `Carousel.php`, `Counter.php`, `Gallery.php`, `Headline.php`, `InsertPost.php`, `ProductCategories.php`, and `StickyColumn.php`