### PR TITLE
Fix names conventions

### DIFF
--- a/.cursor/rules/naming-conventions.mdc
+++ b/.cursor/rules/naming-conventions.mdc
@@ -1,0 +1,60 @@
+---
+description: FrontBlocks Naming Conventions
+globs:
+alwaysApply: true
+---
+
+# FrontBlocks Naming Conventions
+
+## Brand Name Capitalization
+
+Always write "FrontBlocks" with proper capitalization:
+- ✅ Correct: `FrontBlocks`
+- ❌ Incorrect: `frontblocks`, `Frontblocks`, `FRONTBLOCKS`, `front-blocks`
+
+### When to use proper capitalization:
+- In code comments and documentation
+- In user-facing messages and strings
+- In class names (when not following WordPress naming conventions)
+- In readme files and documentation
+- In variable names where appropriate
+
+### Exceptions:
+- File names and directory names: Use lowercase `frontblocks` (e.g., `frontblocks.php`)
+- Text domains: Use lowercase with hyphens `frontblocks`
+- Function prefixes: Follow WordPress conventions with lowercase `frontblocks_` or `fb_`
+- CSS classes: Use lowercase with hyphens `frontblocks-` prefix
+- Database table names and option names: Use lowercase
+
+### Examples:
+
+```php
+// Correct - Plugin header comment
+/**
+ * Plugin Name: FrontBlocks
+ * Description: Essential blocks for WordPress
+ */
+
+// Correct - User-facing messages
+__( 'FrontBlocks is active', 'frontblocks' );
+
+// Correct - Code comments
+// Initialize FrontBlocks features.
+
+// Correct - Class names (modern PHP)
+namespace FrontBlocks;
+
+// Correct - File names (WordPress conventions)
+// File: frontblocks.php
+
+// Correct - Function names (WordPress conventions)
+function frontblocks_init() {
+	// FrontBlocks initialization.
+}
+
+// Correct - Text domain
+load_plugin_textdomain( 'frontblocks' );
+```
+
+## Summary
+When referring to the brand or product name in human-readable contexts, always use **FrontBlocks** with capital F and B. For technical identifiers (files, functions, text domains), follow WordPress naming conventions with lowercase.

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -46,8 +46,8 @@ class Settings {
 	 */
 	public function register_menu() {
 		add_theme_page(
-			__( 'Frontblocks Settings', 'frontblocks' ),
-			__( 'Frontblocks', 'frontblocks' ),
+			__( 'FrontBlocks Settings', 'frontblocks' ),
+			__( 'FrontBlocks', 'frontblocks' ),
 			'edit_theme_options',
 			$this->page_slug,
 			array( $this, 'render_page' )
@@ -75,7 +75,7 @@ class Settings {
 			'frontblocks_section_features',
 			__( 'Features', 'frontblocks' ),
 			function () {
-				echo '<p>' . esc_html__( 'Enable or disable Frontblocks features.', 'frontblocks' ) . '</p>';
+				echo '<p>' . esc_html__( 'Enable or disable FrontBlocks features.', 'frontblocks' ) . '</p>';
 			},
 			$this->page_slug
 		);
@@ -114,7 +114,7 @@ class Settings {
 		}
 		?>
 		<div class="wrap">
-			<h1><?php echo esc_html__( 'Frontblocks Settings', 'frontblocks' ); ?></h1>
+			<h1><?php echo esc_html__( 'FrontBlocks Settings', 'frontblocks' ); ?></h1>
 
 			<form method="post" action="options.php" style="margin-top:20px;">
 				<?php


### PR DESCRIPTION
## Summary

Fixed WordPress filter and action naming conventions — filter namespaces must use underscores, not forward slashes.

- Updated all `wp.hooks.addFilter()` and `wp.hooks.addAction()` calls to replace `frontblocks/` namespace prefix with `frontblocks_` (e.g. `frontblocks/animation-controls` → `frontblocks_animation_controls`)
- Affected files: carousel, animations, gallery, sticky column, and insert-post option scripts and their compiled counterparts
- Fixed the block type name for the insert-post block: `frontblocks/insert-post` → `frontblocks_insert_post`
- Reverted deploy workflow SVN secrets back to `SVN_PASSWORD` / `SVN_USERNAME` (undid the `_FIRMAFY` suffix from PR #27)