### PR TITLE
fix license

### DIFF
--- a/assets/admin/settings.css
+++ b/assets/admin/settings.css
@@ -1299,3 +1299,287 @@ video {
 	}
 }
 
+
+/* =============================================
+   License Management Styles (Complete & Independent)
+   Based on FormsCRM but standalone for FrontBlocks
+   ============================================= */
+
+/* License Wrapper - Grid Layout */
+.formscrm-license-wrapper {
+	display: grid;
+	grid-template-columns: 1fr 320px;
+	gap: 24px;
+	max-width: 1200px;
+	margin: 20px 0;
+}
+
+@media (max-width: 900px) {
+	.formscrm-license-wrapper {
+		grid-template-columns: 1fr;
+	}
+}
+
+/* Main Card */
+.formscrm-card {
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 12px;
+	padding: 32px;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+.formscrm-card-header {
+	margin-bottom: 24px;
+	padding-bottom: 20px;
+	border-bottom: 1px solid #e5e7eb;
+}
+
+.formscrm-card-header h2 {
+	margin: 0 0 8px 0;
+	font-size: 1.5rem;
+	font-weight: 600;
+	color: #1f2937;
+}
+
+.formscrm-card-header p {
+	margin: 0;
+	color: #6b7280;
+	font-size: 0.875rem;
+}
+
+/* Form Elements */
+.formscrm-form-group {
+	margin-bottom: 24px;
+}
+
+.formscrm-label {
+	display: block;
+	font-weight: 600;
+	color: #374151;
+	margin-bottom: 8px;
+	font-size: 0.875rem;
+}
+
+.formscrm-input-group {
+	display: flex;
+	gap: 12px;
+	align-items: center;
+}
+
+.formscrm-input {
+	flex: 1;
+	padding: 12px 16px;
+	border: 1px solid #d1d5db;
+	border-radius: 8px;
+	font-size: 1rem;
+	transition: all 0.2s;
+	background: #fff;
+}
+
+.formscrm-input:focus {
+	outline: none;
+	border-color: #8b5cf6;
+	box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15);
+}
+
+.formscrm-input[readonly] {
+	background: #f9fafb;
+	color: #6b7280;
+	cursor: not-allowed;
+}
+
+/* Deactivate Label */
+.formscrm-deactivate-label {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 12px 16px;
+	background: #fef2f2;
+	border: 1px solid #fecaca;
+	border-radius: 8px;
+	cursor: pointer;
+	transition: background 0.2s;
+	white-space: nowrap;
+}
+
+.formscrm-deactivate-label:hover {
+	background: #fee2e2;
+}
+
+.formscrm-deactivate-label input {
+	margin: 0;
+}
+
+.formscrm-deactivate-label span {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: #dc2626;
+}
+
+/* Help Text */
+.formscrm-help-text {
+	margin: 8px 0 0 0;
+	font-size: 0.75rem;
+	color: #9ca3af;
+}
+
+/* Status Box */
+.formscrm-status-box {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 14px 18px;
+	border-radius: 8px;
+	border: 2px solid;
+}
+
+.formscrm-status-active {
+	background: #dcfce7;
+	border-color: #86efac;
+	color: #166534;
+}
+
+.formscrm-status-expired {
+	background: #fee2e2;
+	border-color: #fca5a5;
+	color: #991b1b;
+}
+
+.formscrm-status-inactive {
+	background: #fef9c3;
+	border-color: #fde047;
+	color: #854d0e;
+}
+
+.formscrm-status-icon {
+	display: flex;
+	flex-shrink: 0;
+}
+
+.formscrm-icon,
+.fcod-icon {
+	width: 22px;
+	height: 22px;
+}
+
+.formscrm-status-text {
+	font-weight: 700;
+	font-size: 1rem;
+}
+
+/* Notices */
+.formscrm-notice {
+	padding: 14px 18px;
+	border-radius: 8px;
+	margin-bottom: 20px;
+}
+
+.formscrm-notice p {
+	margin: 0;
+	font-size: 0.875rem;
+	line-height: 1.5;
+}
+
+.formscrm-notice a {
+	font-weight: 600;
+	text-decoration: underline;
+}
+
+.formscrm-notice-info {
+	background: #f0f9ff;
+	border: 1px solid #bfdbfe;
+	color: #1e40af;
+}
+
+.formscrm-notice-info a {
+	color: #1d4ed8;
+}
+
+.formscrm-notice-error {
+	background: #fef2f2;
+	border: 1px solid #fecaca;
+	color: #991b1b;
+}
+
+.formscrm-notice-error a {
+	color: #dc2626;
+}
+
+/* Form Actions */
+.formscrm-form-actions {
+	margin-top: 24px;
+	padding-top: 24px;
+	border-top: 1px solid #e5e7eb;
+}
+
+/* Buttons - FrontBlocks Purple Style */
+.formscrm-button {
+	display: inline-flex;
+	align-items: center;
+	padding: 12px 24px;
+	border-radius: 8px;
+	font-size: 1rem;
+	font-weight: 600;
+	cursor: pointer;
+	transition: all 0.2s;
+	border: none;
+}
+
+.formscrm-button-primary {
+	background: #8b5cf6;
+	color: #fff;
+}
+
+.formscrm-button-primary:hover {
+	background: #7c3aed;
+	box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+/* Info Card (Sidebar) */
+.formscrm-info-card {
+	background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+	border: 1px solid #e2e8f0;
+	border-radius: 12px;
+	padding: 24px;
+	height: fit-content;
+}
+
+.formscrm-info-card h3 {
+	margin: 0 0 12px 0;
+	font-size: 1.125rem;
+	font-weight: 700;
+	color: #1e293b;
+}
+
+.formscrm-info-card p {
+	margin: 0 0 16px 0;
+	font-size: 0.875rem;
+	color: #64748b;
+	line-height: 1.5;
+}
+
+/* Benefits List */
+.formscrm-benefits-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.formscrm-benefits-list li {
+	position: relative;
+	padding-left: 28px;
+	margin-bottom: 10px;
+	font-size: 0.875rem;
+	color: #475569;
+}
+
+.formscrm-benefits-list li::before {
+	content: "✓";
+	position: absolute;
+	left: 0;
+	top: 0;
+	color: #8b5cf6;
+	font-weight: 700;
+	font-size: 1.125rem;
+}

--- a/frontblocks.php
+++ b/frontblocks.php
@@ -3,7 +3,7 @@
  * Plugin Name: FrontBlocks for GeneratePress
  * Plugin URI:  https://wordpress.org/plugins/frontblocks/
  * Description: Blocks and helpers that extends GeneratePress blocks.
- * Version:     1.3.1
+ * Version:     1.3.2
  * Author:      Closemarketing
  * Author URI:  https://close.marketing
  * Text Domain: frontblocks

--- a/frontblocks.php
+++ b/frontblocks.php
@@ -3,7 +3,7 @@
  * Plugin Name: FrontBlocks for GeneratePress
  * Plugin URI:  https://wordpress.org/plugins/frontblocks/
  * Description: Blocks and helpers that extends GeneratePress blocks.
- * Version:     1.3.2
+ * Version:     1.3.1
  * Author:      Closemarketing
  * Author URI:  https://close.marketing
  * Text Domain: frontblocks

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1294,7 +1294,7 @@ class Settings {
 			);
 
 			$settings->render();
-			?>
+		?>
 		</div>
 		<?php
 	}

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -539,23 +539,8 @@ class Settings {
 			);
 		}
 
-		// License section (only if PRO is active).
-		if ( frbl_is_pro_active() ) {
-			add_settings_section(
-				'frontblocks_section_license',
-				__( 'License', 'frontblocks' ),
-				array( $this, 'section_license_callback' ),
-				$this->page_slug
-			);
-
-			add_settings_field(
-				'frblp_license_info',
-				__( 'License Information', 'frontblocks' ),
-				array( $this, 'field_license_key' ),
-				$this->page_slug,
-				'frontblocks_section_license'
-			);
-		}
+		// Note: License section is rendered separately outside the main form.
+		// See render_license_section() method called from render_page().
 
 		do_action( 'frontblocks_register_settings' );
 	}
@@ -666,6 +651,13 @@ class Settings {
 					</div>
 				</form>
 
+				<?php
+				// Render license section separately (outside main form) if PRO is active.
+				if ( frbl_is_pro_active() ) {
+					$this->render_license_section();
+				}
+				?>
+
 				<!-- Footer Info -->
 				<div class="tw-mt-8 tw-text-center tw-text-sm tw-text-gray-500">
 					<?php
@@ -738,9 +730,6 @@ class Settings {
 		// Check if this is a section with callback only (like active_blocks).
 		$is_callback_only = ! $has_fields && $section['callback'];
 
-		// Check if this is the license section - render it full width.
-		$is_license_section = 'frontblocks_section_license' === $section['id'];
-
 		// Check if this is the custom post types section - render it full width.
 		$is_cpt_section = 'frontblocks_section_custom_post_types' === $section['id'];
 
@@ -759,8 +748,8 @@ class Settings {
 			return;
 		}
 
-		if ( $is_license_section || $is_cpt_section ) {
-			// Render license or CPT section as a full-width card.
+		if ( $is_cpt_section ) {
+			// Render CPT section as a full-width card.
 			?>
 			<div class="frbl-card tw-bg-white tw-rounded-lg tw-shadow-sm tw-border tw-border-gray-200 tw-overflow-hidden frbl-animate-slide-in tw-mb-8">
 				<div class="tw-px-6 tw-py-5 tw-border-b tw-border-gray-200 tw-bg-gradient-to-r tw-from-gray-50 tw-to-white">
@@ -1252,72 +1241,62 @@ class Settings {
 	}
 
 	/**
-	 * License section description.
+	 * Render license section (separate from main form).
 	 *
 	 * @return void
 	 */
-	public function section_license_callback() {
-		echo '<p>' . esc_html__( 'Manage your FrontBlocks PRO license.', 'frontblocks' ) . '</p>';
-	}
-
-	/**
-	 * Render license key field.
-	 *
-	 * Uses FormsCRMSettings from wp-plugin-license-manager library.
-	 *
-	 * @return void
-	 */
-	public function field_license_key() {
+	private function render_license_section() {
 		global $frblp_license;
 
-		// Close the main settings form before rendering license section.
 		?>
-		</form>
+		<div class="tw-mt-6">
+			<?php
+			// Check if license instance exists.
+			if ( ! $frblp_license ) {
+				?>
+				<div class="tw-p-4 tw-rounded-lg tw-bg-red-50 tw-border tw-border-red-200">
+					<p class="tw-text-sm tw-text-red-700">
+						<?php echo esc_html__( 'License manager not initialized.', 'frontblocks' ); ?>
+					</p>
+				</div>
+				<?php
+				return;
+			}
 
+			// Check if FormsCRMSettings class exists (requires FrontBlocks PRO).
+			if ( ! class_exists( '\Closemarketing\WPLicenseManager\FormsCRMSettings' ) ) {
+				?>
+				<div class="tw-p-4 tw-rounded-lg tw-bg-yellow-50 tw-border tw-border-yellow-200">
+					<p class="tw-text-sm tw-text-yellow-700">
+						<?php echo esc_html__( 'License management requires FrontBlocks PRO to be installed and active.', 'frontblocks' ); ?>
+					</p>
+				</div>
+				<?php
+				return;
+			}
+
+			// Use FormsCRMSettings renderer (same as formscrm-inmovilla and PBC).
+			$settings = new \Closemarketing\WPLicenseManager\FormsCRMSettings(
+				$frblp_license,
+				array(
+					'title'        => __( 'FrontBlocks PRO License', 'frontblocks' ),
+					'description'  => __( 'Manage your license to receive automatic updates and support.', 'frontblocks' ),
+					'plugin_name'  => 'FrontBlocks PRO',
+					'purchase_url' => 'https://close.technology/wordpress-plugins/frontblocks-pro/',
+					'renew_url'    => 'https://close.technology/my-account/',
+					'benefits'     => array(
+						__( 'Automatic plugin updates', 'frontblocks' ),
+						__( 'Access to new features', 'frontblocks' ),
+						__( 'Priority support', 'frontblocks' ),
+						__( 'Security patches', 'frontblocks' ),
+					),
+				)
+			);
+
+			$settings->render();
+			?>
+		</div>
 		<?php
-		// Check if license instance exists.
-		if ( ! $frblp_license ) {
-			?>
-			<div class="tw-p-4 tw-rounded-lg tw-bg-red-50 tw-border tw-border-red-200">
-				<p class="tw-text-sm tw-text-red-700">
-					<?php echo esc_html__( 'License manager not initialized.', 'frontblocks' ); ?>
-				</p>
-			</div>
-			<?php
-			return;
-		}
-
-		// Check if FormsCRMSettings class exists (requires FrontBlocks PRO).
-		if ( ! class_exists( '\Closemarketing\WPLicenseManager\FormsCRMSettings' ) ) {
-			?>
-			<div class="tw-p-4 tw-rounded-lg tw-bg-yellow-50 tw-border tw-border-yellow-200">
-				<p class="tw-text-sm tw-text-yellow-700">
-					<?php echo esc_html__( 'License management requires FrontBlocks PRO to be installed and active.', 'frontblocks' ); ?>
-				</p>
-			</div>
-			<?php
-			return;
-		}
-
-		// Use FormsCRMSettings renderer (same as formscrm-inmovilla and PBC).
-		$settings = new \Closemarketing\WPLicenseManager\FormsCRMSettings(
-			$frblp_license,
-			array(
-				'title'        => __( 'FrontBlocks PRO License', 'frontblocks' ),
-				'description'  => __( 'Manage your license to receive automatic updates and support.', 'frontblocks' ),
-				'plugin_name'  => 'FrontBlocks PRO',
-				'purchase_url' => 'https://close.technology/wordpress-plugins/frontblocks-pro/',
-				'renew_url'    => 'https://close.technology/my-account/',
-				'benefits'     => array(
-					__( 'Automatic plugin updates', 'frontblocks' ),
-					__( 'Access to new features', 'frontblocks' ),
-					__( 'Priority support', 'frontblocks' ),
-					__( 'Security patches', 'frontblocks' ),
-				),
-			)
-		);
-
-		$settings->render();
 	}
 
 	/**
@@ -1364,9 +1343,38 @@ class Settings {
 			return array();
 		}
 
-		$sanitized = array();
+		// Get current options to preserve unchecked checkboxes.
+		$current_options = get_option( 'frontblocks_settings', array() );
+
+		// Initialize sanitized array with current values.
+		$sanitized = $current_options;
+
+		// List of all boolean options (checkboxes).
+		$boolean_options = array(
+			$this->option_enable_testimonials,
+			$this->option_enable_reading_progress,
+			$this->option_enable_back_button,
+			$this->option_enable_events,
+			$this->option_enable_gutenberg,
+			$this->option_enable_simple_prices_variable_products,
+			$this->option_enable_after_add_to_cart,
+			$this->option_deactivate_short_description,
+			$this->option_move_content_to_short_description,
+			$this->option_disable_zoom_images,
+			$this->option_add_share_buttons,
+			$this->option_deactivate_product_tabs,
+			$this->option_horizontal_product_form,
+			$this->option_enable_custom_post_types,
+		);
+
+		// Initialize all boolean options to false (unchecked checkboxes are not submitted).
+		foreach ( $boolean_options as $option ) {
+			$sanitized[ $option ] = false;
+		}
+
+		// Process submitted values.
 		foreach ( $value as $key => $val ) {
-			if ( $this->option_enable_testimonials === $key || $this->option_enable_reading_progress === $key || $this->option_enable_back_button === $key || $this->option_enable_events === $key || $this->option_enable_gutenberg === $key || $this->option_enable_simple_prices_variable_products === $key || $this->option_enable_after_add_to_cart === $key || $this->option_deactivate_short_description === $key || $this->option_move_content_to_short_description === $key || $this->option_disable_zoom_images === $key || $this->option_add_share_buttons === $key || $this->option_deactivate_product_tabs === $key || $this->option_horizontal_product_form === $key || $this->option_enable_custom_post_types === $key ) {
+			if ( in_array( $key, $boolean_options, true ) ) {
 				$sanitized[ $key ] = (bool) $val;
 			} elseif ( $this->option_events_type === $key ) {
 				// Sanitize events type: only allow 'cpt' or 'posts'.
@@ -1377,7 +1385,6 @@ class Settings {
 		// Ensure mutual exclusion: if both description options are enabled, keep only the last one changed.
 		if ( ! empty( $sanitized[ $this->option_deactivate_short_description ] ) && ! empty( $sanitized[ $this->option_move_content_to_short_description ] ) ) {
 			// Get current saved values to determine which one was just changed.
-			$current_options    = get_option( 'frontblocks_settings', array() );
 			$current_deactivate = ! empty( $current_options[ $this->option_deactivate_short_description ] );
 			$current_move       = ! empty( $current_options[ $this->option_move_content_to_short_description ] );
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1263,119 +1263,49 @@ class Settings {
 	/**
 	 * Render license key field.
 	 *
-	 * Uses wp-plugin-license-manager library.
+	 * Uses FormsCRMSettings from wp-plugin-license-manager library.
 	 *
 	 * @return void
 	 */
 	public function field_license_key() {
-		// Get license data from FrontBlocks PRO.
-		$license_status = function_exists( 'frblp_get_license_status' ) ? frblp_get_license_status() : 'inactive';
-		$license_key    = function_exists( 'frblp_get_stored_license_key' ) ? frblp_get_stored_license_key() : '';
+		global $frblp_license;
 
-		$status_text  = '';
-		$status_class = '';
-		$status_icon  = '';
-
-		switch ( $license_status ) {
-			case 'active':
-				$status_text  = __( 'Active', 'frontblocks' );
-				$status_class = 'tw-bg-green-100 tw-text-green-800 tw-border-green-300';
-				$status_icon  = '<svg class="tw-w-5 tw-h-5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>';
-				break;
-			case 'expired':
-				$status_text  = __( 'Expired', 'frontblocks' );
-				$status_class = 'tw-bg-red-100 tw-text-red-800 tw-border-red-300';
-				$status_icon  = '<svg class="tw-w-5 tw-h-5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/></svg>';
-				break;
-			default: // inactive.
-				$status_text  = __( 'Not Activated', 'frontblocks' );
-				$status_class = 'tw-bg-yellow-100 tw-text-yellow-800 tw-border-yellow-300';
-				$status_icon  = '<svg class="tw-w-5 tw-h-5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>';
-				break;
-		}
+		// Close the main settings form before rendering license section.
 		?>
 		</form>
-		<form method="post" action="options.php" class="tw-mt-0">
-			<?php settings_fields( 'frontblocks-pro_license' ); ?>
-			<div class="tw-space-y-4" id="frblp-license-section">
-				<!-- License Key Input -->
-				<div>
-					<label for="frontblocks-pro_license_apikey" class="tw-block tw-text-sm tw-font-medium tw-text-gray-900 tw-mb-2">
-						<?php echo esc_html__( 'License Key', 'frontblocks' ); ?>
-					</label>
-					<div class="tw-flex tw-gap-2">
-						<input type="text" 
-							id="frontblocks-pro_license_apikey" 
-							name="frontblocks-pro_license_apikey" 
-							value="<?php echo esc_attr( $license_key ); ?>"
-							placeholder="<?php echo esc_attr__( 'Enter your license key', 'frontblocks' ); ?>"
-							class="tw-flex-1 tw-px-4 tw-py-3 tw-border tw-border-gray-300 tw-rounded-lg tw-text-base focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-500 focus:tw-border-transparent"
-							<?php echo 'active' === $license_status ? 'readonly' : ''; ?>
-						/>
-						<?php if ( 'active' === $license_status ) : ?>
-							<label class="tw-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-bg-red-50 tw-border tw-border-red-200 tw-rounded-lg tw-cursor-pointer hover:tw-bg-red-100 tw-transition-colors">
-								<input type="checkbox" name="frontblocks-pro_license_deactivate_checkbox" value="on" class="tw-rounded tw-border-red-300 tw-text-red-600 focus:tw-ring-red-500" />
-								<span class="tw-text-sm tw-font-medium tw-text-red-700"><?php echo esc_html__( 'Deactivate', 'frontblocks' ); ?></span>
-							</label>
-						<?php endif; ?>
-					</div>
-					<p class="tw-text-xs tw-text-gray-500 tw-mt-2">
-						<?php echo esc_html__( 'Enter your license key from your purchase confirmation email.', 'frontblocks' ); ?>
-					</p>
-				</div>
 
-				<!-- License Status -->
-				<div>
-					<label class="tw-block tw-text-sm tw-font-medium tw-text-gray-900 tw-mb-2">
-						<?php echo esc_html__( 'License Status', 'frontblocks' ); ?>
-					</label>
-					<div id="frblp_license_status" class="tw-flex tw-items-center tw-gap-3 tw-px-4 tw-py-3 tw-border tw-rounded-lg <?php echo esc_attr( $status_class ); ?>">
-						<span class="tw-flex-shrink-0">
-							<?php echo $status_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						</span>
-						<span class="tw-font-semibold tw-text-base">
-							<?php echo esc_html( $status_text ); ?>
-						</span>
-					</div>
-				</div>
-
-				<!-- Help Text -->
-				<?php if ( empty( $license_key ) ) : ?>
-					<div class="tw-p-4 tw-rounded-lg tw-bg-gray-50 tw-border tw-border-gray-200">
-						<p class="tw-text-sm tw-text-gray-600">
-							<?php
-							printf(
-								/* translators: %s: purchase link */
-								esc_html__( 'Don\'t have a license? %s to get started.', 'frontblocks' ),
-								'<a href="https://close.technology/wordpress-plugins/frontblocks-pro/?utm_source=frontblocks&utm_medium=plugin&utm_campaign=settings-license" target="_blank" rel="noopener noreferrer" class="tw-text-primary-500 hover:tw-text-primary-600 tw-font-medium">' . esc_html__( 'Purchase FrontBlocks PRO', 'frontblocks' ) . '</a>'
-							);
-							?>
-						</p>
-					</div>
-				<?php endif; ?>
-
-				<?php if ( 'expired' === $license_status ) : ?>
-					<div class="tw-p-4 tw-rounded-lg tw-bg-red-50 tw-border tw-border-red-200">
-						<p class="tw-text-sm tw-text-red-700">
-							<?php
-							printf(
-								/* translators: %s: renewal link */
-								esc_html__( 'Your license has expired. %s to continue receiving updates and support.', 'frontblocks' ),
-								'<a href="https://close.technology/my-account/?utm_source=frontblocks&utm_medium=plugin&utm_campaign=renew-license" target="_blank" rel="noopener noreferrer" class="tw-font-medium tw-underline hover:tw-no-underline">' . esc_html__( 'Renew your license', 'frontblocks' ) . '</a>'
-							);
-							?>
-						</p>
-					</div>
-				<?php endif; ?>
-
-				<!-- Submit Button for License -->
-				<div class="tw-pt-4">
-					<button type="submit" name="submit_license" class="tw-inline-flex tw-items-center tw-px-4 tw-py-2 tw-border tw-border-transparent tw-text-sm tw-font-medium tw-rounded-lg tw-shadow-sm tw-text-white tw-bg-primary-500 hover:tw-bg-primary-600 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-offset-2 focus:tw-ring-primary-500 tw-transition-colors tw-duration-200">
-						<?php echo 'active' === $license_status ? esc_html__( 'Update License', 'frontblocks' ) : esc_html__( 'Activate License', 'frontblocks' ); ?>
-					</button>
-				</div>
-			</div>
 		<?php
+		// Check if license instance exists.
+		if ( ! $frblp_license ) {
+			?>
+			<div class="tw-p-4 tw-rounded-lg tw-bg-red-50 tw-border tw-border-red-200">
+				<p class="tw-text-sm tw-text-red-700">
+					<?php echo esc_html__( 'License manager not initialized.', 'frontblocks' ); ?>
+				</p>
+			</div>
+			<?php
+			return;
+		}
+
+		// Use FormsCRMSettings renderer (same as formscrm-inmovilla and PBC).
+		$settings = new \Closemarketing\WPLicenseManager\FormsCRMSettings(
+			$frblp_license,
+			array(
+				'title'        => __( 'FrontBlocks PRO License', 'frontblocks' ),
+				'description'  => __( 'Manage your license to receive automatic updates and support.', 'frontblocks' ),
+				'plugin_name'  => 'FrontBlocks PRO',
+				'purchase_url' => 'https://close.technology/wordpress-plugins/frontblocks-pro/',
+				'renew_url'    => 'https://close.technology/my-account/',
+				'benefits'     => array(
+					__( 'Automatic plugin updates', 'frontblocks' ),
+					__( 'Access to new features', 'frontblocks' ),
+					__( 'Priority support', 'frontblocks' ),
+					__( 'Security patches', 'frontblocks' ),
+				),
+			)
+		);
+
+		$settings->render();
 	}
 
 	/**

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1287,6 +1287,18 @@ class Settings {
 			return;
 		}
 
+		// Check if FormsCRMSettings class exists (requires FrontBlocks PRO).
+		if ( ! class_exists( '\Closemarketing\WPLicenseManager\FormsCRMSettings' ) ) {
+			?>
+			<div class="tw-p-4 tw-rounded-lg tw-bg-yellow-50 tw-border tw-border-yellow-200">
+				<p class="tw-text-sm tw-text-yellow-700">
+					<?php echo esc_html__( 'License management requires FrontBlocks PRO to be installed and active.', 'frontblocks' ); ?>
+				</p>
+			</div>
+			<?php
+			return;
+		}
+
 		// Use FormsCRMSettings renderer (same as formscrm-inmovilla and PBC).
 		$settings = new \Closemarketing\WPLicenseManager\FormsCRMSettings(
 			$frblp_license,


### PR DESCRIPTION
## Summary

Refactored the PRO license management UI to use the shared `FormsCRMSettings` renderer from the `wp-plugin-license-manager` library.

- Replaced the custom inline license form HTML with a call to `FormsCRMSettings::render()`, matching the pattern used in other Close plugins
- Moved license rendering outside the main settings `<form>` to avoid form nesting issues; it now renders via a dedicated `render_license_section()` private method called from `render_page()`
- Added graceful fallbacks when `$frblp_license` is null or `FormsCRMSettings` class is not available
- Removed the `frontblocks_section_license` settings section registration (license is no longer a WordPress settings field)
- Added license management CSS styles (`settings.css`) for the `formscrm-*` component classes