### PR TITLE
Image animations

### DIFF
--- a/assets/stacked-images/frontblocks-stacked-images-frontend.js
+++ b/assets/stacked-images/frontblocks-stacked-images-frontend.js
@@ -1,0 +1,121 @@
+/**
+ * FrontBlocks Stacked Images Frontend Animation
+ *
+ * @package FrontBlocks
+ */
+
+(function () {
+	'use strict';
+
+	// Track initialized containers to avoid re-initialization.
+	const initializedContainers = new WeakSet();
+
+	/**
+	 * Initialize stacked images animation.
+	 */
+	function initStackedImages() {
+		const containers = document.querySelectorAll('.frbl-stacked-images-wrapper:not(.frbl-initialized)');
+
+		containers.forEach(container => {
+			// Skip if already initialized.
+			if (initializedContainers.has(container)) {
+				return;
+			}
+
+			const direction = container.dataset.direction || 'bottom';
+			const duration = parseInt(container.dataset.duration) || 1000;
+			const delay = parseInt(container.dataset.delay) || 500;
+			const images = container.querySelectorAll('.frbl-stacked-image');
+
+			if (images.length === 0) {
+				return;
+			}
+
+			// Mark as initialized.
+			container.classList.add('frbl-initialized');
+			initializedContainers.add(container);
+
+			// Set initial position for each image based on direction.
+			images.forEach((image, index) => {
+				// Set transition FIRST.
+				image.style.transition = `opacity ${duration}ms ease-out, transform ${duration}ms ease-out`;
+				image.style.position = 'absolute';
+				image.style.top = '0';
+				image.style.left = '0';
+				image.style.width = '100%';
+				image.style.height = '100%';
+				
+				// Generate random rotation between -10 and 10 degrees.
+				const randomRotation = (Math.random() * 20) - 10;
+				image.dataset.rotation = randomRotation;
+				
+				// Force a reflow to ensure styles are applied.
+				void image.offsetHeight;
+
+				// Then set initial state (hidden and off-screen).
+				image.style.opacity = '0';
+				
+				// Set initial transform based on direction with rotation.
+				let initialTransform = '';
+				switch (direction) {
+					case 'bottom':
+						initialTransform = `translateY(100%) rotate(${randomRotation}deg)`;
+						break;
+					case 'top':
+						initialTransform = `translateY(-100%) rotate(${randomRotation}deg)`;
+						break;
+					case 'left':
+						initialTransform = `translateX(-100%) rotate(${randomRotation}deg)`;
+						break;
+					case 'right':
+						initialTransform = `translateX(100%) rotate(${randomRotation}deg)`;
+						break;
+				}
+				image.style.transform = initialTransform;
+			});
+
+			// Animate images one by one using Intersection Observer.
+			const observer = new IntersectionObserver(
+				(entries) => {
+					entries.forEach(entry => {
+						if (entry.isIntersecting) {
+							animateImages(images, duration, delay);
+							observer.unobserve(entry.target);
+						}
+					});
+				},
+				{
+					threshold: 0.2,
+					rootMargin: '0px',
+				}
+			);
+
+			observer.observe(container);
+		});
+	}
+
+	/**
+	 * Animate images sequentially.
+	 *
+	 * @param {NodeList} images List of image elements.
+	 * @param {number} duration Animation duration.
+	 * @param {number} delay Delay between images.
+	 */
+	function animateImages(images, duration, delay) {
+		images.forEach((image, index) => {
+			setTimeout(() => {
+				const rotation = image.dataset.rotation || 0;
+				image.style.opacity = '1';
+				// Final state: no translation, but keep the random rotation.
+				image.style.transform = `translate(0, 0) rotate(${rotation}deg)`;
+			}, index * delay);
+		});
+	}
+
+	// Initialize on DOM ready.
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', initStackedImages);
+	} else {
+		initStackedImages();
+	}
+})();

--- a/assets/stacked-images/frontblocks-stacked-images-option.jsx
+++ b/assets/stacked-images/frontblocks-stacked-images-option.jsx
@@ -1,0 +1,203 @@
+const { registerBlockType } = wp.blocks;
+const { Fragment, useState } = wp.element;
+const { InspectorControls, MediaUpload, MediaUploadCheck, useBlockProps } = wp.blockEditor;
+const { PanelBody, SelectControl, RangeControl, Button, Placeholder } = wp.components;
+const { __ } = wp.i18n;
+
+/**
+ * Edit component for Stacked Images block.
+ *
+ * @param {Object} props - Block properties.
+ * @return {JSX.Element} Block edit component.
+ */
+function StackedImagesEdit(props) {
+	const { attributes, setAttributes } = props;
+	const { images, direction, animationDuration, animationDelay, containerHeight } = attributes;
+
+	const blockProps = useBlockProps();
+
+	const onSelectImages = (newImages) => {
+		setAttributes({
+			images: newImages.map(img => ({
+				id: img.id,
+				url: img.url,
+				alt: img.alt || '',
+			})),
+		});
+	};
+
+	const removeImage = (indexToRemove) => {
+		const newImages = images.filter((img, index) => index !== indexToRemove);
+		setAttributes({ images: newImages });
+	};
+
+	return (
+		<Fragment>
+			<InspectorControls>
+				<PanelBody title={__('Images', 'frontblocks')} initialOpen={true}>
+					<MediaUploadCheck>
+						<MediaUpload
+							onSelect={onSelectImages}
+							allowedTypes={['image']}
+							multiple={true}
+							value={images.map(img => img.id)}
+							render={({ open }) => (
+								<Button 
+									isPrimary 
+									onClick={open}
+									style={{ width: '100%', marginBottom: '10px' }}
+								>
+									{images.length === 0 
+										? __('Add Images', 'frontblocks')
+										: __('Change Images (' + images.length + ')', 'frontblocks')
+									}
+								</Button>
+							)}
+						/>
+					</MediaUploadCheck>
+					{images.length > 0 && (
+						<Button 
+							isDestructive 
+							onClick={() => setAttributes({ images: [] })}
+							style={{ width: '100%' }}
+						>
+							{__('Remove All Images', 'frontblocks')}
+						</Button>
+					)}
+				</PanelBody>
+
+				<PanelBody title={__('Settings', 'frontblocks')} initialOpen={true}>
+					<SelectControl
+						label={__('Animation Direction', 'frontblocks')}
+						value={direction}
+						options={[
+							{ label: __('From Bottom', 'frontblocks'), value: 'bottom' },
+							{ label: __('From Top', 'frontblocks'), value: 'top' },
+							{ label: __('From Left', 'frontblocks'), value: 'left' },
+							{ label: __('From Right', 'frontblocks'), value: 'right' },
+						]}
+						onChange={(value) => setAttributes({ direction: value })}
+					/>
+					<RangeControl
+						label={__('Animation Duration (ms)', 'frontblocks')}
+						value={animationDuration}
+						onChange={(value) => setAttributes({ animationDuration: value })}
+						min={200}
+						max={3000}
+						step={100}
+					/>
+					<RangeControl
+						label={__('Delay Between Images (ms)', 'frontblocks')}
+						value={animationDelay}
+						onChange={(value) => setAttributes({ animationDelay: value })}
+						min={0}
+						max={2000}
+						step={100}
+					/>
+					<RangeControl
+						label={__('Container Height (px)', 'frontblocks')}
+						value={containerHeight}
+						onChange={(value) => setAttributes({ containerHeight: value })}
+						min={200}
+						max={1000}
+						step={50}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<div {...blockProps}>
+				<div className="frbl-stacked-images-editor">
+					{images.length === 0 ? (
+						<Placeholder
+							icon="format-gallery"
+							label={__('Stacked Images', 'frontblocks')}
+							instructions={__('Use the settings panel on the right to add images →', 'frontblocks')}
+						/>
+					) : (
+						<div>
+							<div 
+								className="frbl-stacked-images-preview" 
+								style={{ height: containerHeight + 'px', position: 'relative' }}
+							>
+								{images.map((image, index) => (
+									<div
+										key={index}
+										className="frbl-stacked-image-preview"
+										style={{
+											position: 'absolute',
+											top: 0,
+											left: 0,
+											width: '100%',
+											height: '100%',
+											zIndex: index + 1,
+											transform: `rotate(${(Math.random() * 20) - 10}deg)`,
+										}}
+									>
+										<img
+											src={image.url}
+											alt={image.alt}
+											style={{
+												width: '100%',
+												height: '100%',
+												objectFit: 'contain',
+												boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
+											}}
+										/>
+									</div>
+								))}
+							</div>
+							<div style={{ marginTop: '20px', textAlign: 'center', padding: '10px', background: '#f0f0f0', borderRadius: '4px' }}>
+								<p style={{ margin: '0', fontSize: '13px', color: '#666' }}>
+									<strong>{images.length}</strong> {images.length === 1 ? __('image', 'frontblocks') : __('images', 'frontblocks')} | 
+									{__(' Direction: ', 'frontblocks')} <strong>{direction}</strong> | 
+									{__(' Duration: ', 'frontblocks')} <strong>{animationDuration}ms</strong> | 
+									{__(' Delay: ', 'frontblocks')} <strong>{animationDelay}ms</strong>
+								</p>
+							</div>
+						</div>
+					)}
+				</div>
+			</div>
+		</Fragment>
+	);
+}
+
+// Register the block.
+registerBlockType('frontblocks/stacked-images', {
+	title: __('Stacked Images', 'frontblocks'),
+	description: __('Display images with stacked animation effect from different directions.', 'frontblocks'),
+	category: 'media',
+	icon: 'format-gallery',
+	keywords: [
+		__('images', 'frontblocks'),
+		__('stacked', 'frontblocks'),
+		__('animation', 'frontblocks'),
+		__('gallery', 'frontblocks'),
+	],
+	attributes: {
+		images: {
+			type: 'array',
+			default: [],
+		},
+		direction: {
+			type: 'string',
+			default: 'bottom',
+		},
+		animationDuration: {
+			type: 'number',
+			default: 1000,
+		},
+		animationDelay: {
+			type: 'number',
+			default: 500,
+		},
+		containerHeight: {
+			type: 'number',
+			default: 500,
+		},
+	},
+	edit: StackedImagesEdit,
+	save: function () {
+		return null; // Dynamic block, render on server side.
+	},
+});

--- a/assets/stacked-images/frontblocks-stacked-images.css
+++ b/assets/stacked-images/frontblocks-stacked-images.css
@@ -1,0 +1,109 @@
+/**
+ * FrontBlocks Stacked Images Styles
+ *
+ * @package FrontBlocks
+ */
+
+/* Wrapper */
+.frbl-stacked-images-wrapper {
+	position: relative;
+	width: 100%;
+	overflow: visible;
+	display: block;
+	background: transparent;
+	padding: 50px;
+	margin: -50px;
+}
+
+/* Container */
+.frbl-stacked-images-container {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: visible;
+}
+
+/* Individual image */
+.frbl-stacked-image {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	will-change: transform, opacity;
+	opacity: 0;
+	visibility: hidden;
+	overflow: visible;
+}
+
+/* Show when initialized */
+.frbl-initialized .frbl-stacked-image {
+	visibility: visible;
+}
+
+.frbl-stacked-image img {
+	max-width: 100%;
+	max-height: 100%;
+	width: auto;
+	height: auto;
+	object-fit: contain;
+	display: block;
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Placeholder */
+.frbl-stacked-images-placeholder {
+	padding: 40px;
+	text-align: center;
+	background: #f0f0f0;
+	border: 2px dashed #ccc;
+	border-radius: 8px;
+	color: #666;
+	font-size: 16px;
+}
+
+/* Editor styles */
+.frbl-stacked-images-editor {
+	min-height: 200px;
+}
+
+.frbl-stacked-images-preview {
+	border: 2px dashed #ddd;
+	border-radius: 8px;
+	overflow: visible;
+	background: #fafafa;
+	position: relative;
+	padding: 50px;
+	margin: 20px;
+}
+
+.frbl-stacked-image-preview {
+	border-radius: 4px;
+	overflow: visible;
+	transition: transform 0.3s ease;
+}
+
+.frbl-stacked-image-preview:hover {
+	transform: scale(1.02) !important;
+	z-index: 999 !important;
+}
+
+.frbl-stacked-image-preview img {
+	display: block;
+	transition: all 0.3s ease;
+	pointer-events: none;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+	.frbl-stacked-images-wrapper {
+		height: auto !important;
+		min-height: 300px;
+	}
+}

--- a/assets/stacked-images/frontblocks-stacked-images.js
+++ b/assets/stacked-images/frontblocks-stacked-images.js
@@ -1,0 +1,227 @@
+"use strict";
+
+var registerBlockType = wp.blocks.registerBlockType;
+var _wp$element = wp.element,
+  Fragment = _wp$element.Fragment,
+  useState = _wp$element.useState;
+var _wp$blockEditor = wp.blockEditor,
+  InspectorControls = _wp$blockEditor.InspectorControls,
+  MediaUpload = _wp$blockEditor.MediaUpload,
+  MediaUploadCheck = _wp$blockEditor.MediaUploadCheck,
+  useBlockProps = _wp$blockEditor.useBlockProps;
+var _wp$components = wp.components,
+  PanelBody = _wp$components.PanelBody,
+  SelectControl = _wp$components.SelectControl,
+  RangeControl = _wp$components.RangeControl,
+  Button = _wp$components.Button,
+  Placeholder = _wp$components.Placeholder;
+var __ = wp.i18n.__;
+
+/**
+ * Edit component for Stacked Images block.
+ *
+ * @param {Object} props - Block properties.
+ * @return {JSX.Element} Block edit component.
+ */
+function StackedImagesEdit(props) {
+  var attributes = props.attributes,
+    setAttributes = props.setAttributes;
+  var images = attributes.images,
+    direction = attributes.direction,
+    animationDuration = attributes.animationDuration,
+    animationDelay = attributes.animationDelay,
+    containerHeight = attributes.containerHeight;
+  var blockProps = useBlockProps();
+  var onSelectImages = function onSelectImages(newImages) {
+    setAttributes({
+      images: newImages.map(function (img) {
+        return {
+          id: img.id,
+          url: img.url,
+          alt: img.alt || ''
+        };
+      })
+    });
+  };
+  var removeImage = function removeImage(indexToRemove) {
+    var newImages = images.filter(function (img, index) {
+      return index !== indexToRemove;
+    });
+    setAttributes({
+      images: newImages
+    });
+  };
+  return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(InspectorControls, null, /*#__PURE__*/React.createElement(PanelBody, {
+    title: __('Images', 'frontblocks'),
+    initialOpen: true
+  }, /*#__PURE__*/React.createElement(MediaUploadCheck, null, /*#__PURE__*/React.createElement(MediaUpload, {
+    onSelect: onSelectImages,
+    allowedTypes: ['image'],
+    multiple: true,
+    value: images.map(function (img) {
+      return img.id;
+    }),
+    render: function render(_ref) {
+      var open = _ref.open;
+      return /*#__PURE__*/React.createElement(Button, {
+        isPrimary: true,
+        onClick: open,
+        style: {
+          width: '100%',
+          marginBottom: '10px'
+        }
+      }, images.length === 0 ? __('Add Images', 'frontblocks') : __('Change Images (' + images.length + ')', 'frontblocks'));
+    }
+  })), images.length > 0 && /*#__PURE__*/React.createElement(Button, {
+    isDestructive: true,
+    onClick: function onClick() {
+      return setAttributes({
+        images: []
+      });
+    },
+    style: {
+      width: '100%'
+    }
+  }, __('Remove All Images', 'frontblocks'))), /*#__PURE__*/React.createElement(PanelBody, {
+    title: __('Settings', 'frontblocks'),
+    initialOpen: true
+  }, /*#__PURE__*/React.createElement(SelectControl, {
+    label: __('Animation Direction', 'frontblocks'),
+    value: direction,
+    options: [{
+      label: __('From Bottom', 'frontblocks'),
+      value: 'bottom'
+    }, {
+      label: __('From Top', 'frontblocks'),
+      value: 'top'
+    }, {
+      label: __('From Left', 'frontblocks'),
+      value: 'left'
+    }, {
+      label: __('From Right', 'frontblocks'),
+      value: 'right'
+    }],
+    onChange: function onChange(value) {
+      return setAttributes({
+        direction: value
+      });
+    }
+  }), /*#__PURE__*/React.createElement(RangeControl, {
+    label: __('Animation Duration (ms)', 'frontblocks'),
+    value: animationDuration,
+    onChange: function onChange(value) {
+      return setAttributes({
+        animationDuration: value
+      });
+    },
+    min: 200,
+    max: 3000,
+    step: 100
+  }), /*#__PURE__*/React.createElement(RangeControl, {
+    label: __('Delay Between Images (ms)', 'frontblocks'),
+    value: animationDelay,
+    onChange: function onChange(value) {
+      return setAttributes({
+        animationDelay: value
+      });
+    },
+    min: 0,
+    max: 2000,
+    step: 100
+  }), /*#__PURE__*/React.createElement(RangeControl, {
+    label: __('Container Height (px)', 'frontblocks'),
+    value: containerHeight,
+    onChange: function onChange(value) {
+      return setAttributes({
+        containerHeight: value
+      });
+    },
+    min: 200,
+    max: 1000,
+    step: 50
+  }))), /*#__PURE__*/React.createElement("div", blockProps, /*#__PURE__*/React.createElement("div", {
+    className: "frbl-stacked-images-editor"
+  }, images.length === 0 ? /*#__PURE__*/React.createElement(Placeholder, {
+    icon: "format-gallery",
+    label: __('Stacked Images', 'frontblocks'),
+    instructions: __('Use the settings panel on the right to add images →', 'frontblocks')
+  }) : /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
+    className: "frbl-stacked-images-preview",
+    style: {
+      height: containerHeight + 'px',
+      position: 'relative'
+    }
+  }, images.map(function (image, index) {
+    return /*#__PURE__*/React.createElement("div", {
+      key: index,
+      className: "frbl-stacked-image-preview",
+      style: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        zIndex: index + 1,
+        transform: "rotate(".concat(Math.random() * 20 - 10, "deg)")
+      }
+    }, /*#__PURE__*/React.createElement("img", {
+      src: image.url,
+      alt: image.alt,
+      style: {
+        width: '100%',
+        height: '100%',
+        objectFit: 'contain',
+        boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)'
+      }
+    }));
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      marginTop: '20px',
+      textAlign: 'center',
+      padding: '10px',
+      background: '#f0f0f0',
+      borderRadius: '4px'
+    }
+  }, /*#__PURE__*/React.createElement("p", {
+    style: {
+      margin: '0',
+      fontSize: '13px',
+      color: '#666'
+    }
+  }, /*#__PURE__*/React.createElement("strong", null, images.length), " ", images.length === 1 ? __('image', 'frontblocks') : __('images', 'frontblocks'), " |", __(' Direction: ', 'frontblocks'), " ", /*#__PURE__*/React.createElement("strong", null, direction), " |", __(' Duration: ', 'frontblocks'), " ", /*#__PURE__*/React.createElement("strong", null, animationDuration, "ms"), " |", __(' Delay: ', 'frontblocks'), " ", /*#__PURE__*/React.createElement("strong", null, animationDelay, "ms")))))));
+}
+
+// Register the block.
+registerBlockType('frontblocks/stacked-images', {
+  title: __('Stacked Images', 'frontblocks'),
+  description: __('Display images with stacked animation effect from different directions.', 'frontblocks'),
+  category: 'media',
+  icon: 'format-gallery',
+  keywords: [__('images', 'frontblocks'), __('stacked', 'frontblocks'), __('animation', 'frontblocks'), __('gallery', 'frontblocks')],
+  attributes: {
+    images: {
+      type: 'array',
+      default: []
+    },
+    direction: {
+      type: 'string',
+      default: 'bottom'
+    },
+    animationDuration: {
+      type: 'number',
+      default: 1000
+    },
+    animationDelay: {
+      type: 'number',
+      default: 500
+    },
+    containerHeight: {
+      type: 'number',
+      default: 500
+    }
+  },
+  edit: StackedImagesEdit,
+  save: function save() {
+    return null; // Dynamic block, render on server side.
+  }
+});

--- a/includes/Frontend/StackedImages.php
+++ b/includes/Frontend/StackedImages.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Stacked Images module for FrontBlocks.
+ *
+ * @package    FrontBlocks
+ * @author     David Perez <david@close.technology>
+ * @copyright  2025 Closemarketing
+ * @version    1.0
+ */
+
+namespace FrontBlocks\Frontend;
+
+use WP_Block_Type_Registry;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * StackedImages class.
+ *
+ * @since 1.0.0
+ */
+class StackedImages {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'register_stacked_images_block' ), 20 );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
+	}
+
+	/**
+	 * Enqueue frontend scripts and styles.
+	 *
+	 * @return void
+	 */
+	public function enqueue_frontend_scripts() {
+		wp_register_style(
+			'frontblocks-stacked-images-style',
+			FRBL_PLUGIN_URL . 'assets/stacked-images/frontblocks-stacked-images.css',
+			array(),
+			FRBL_VERSION
+		);
+
+		wp_register_script(
+			'frontblocks-stacked-images-frontend',
+			FRBL_PLUGIN_URL . 'assets/stacked-images/frontblocks-stacked-images-frontend.js',
+			array(),
+			FRBL_VERSION,
+			true
+		);
+
+		if ( is_admin() || has_block( 'frontblocks/stacked-images' ) ) {
+			wp_enqueue_style( 'frontblocks-stacked-images-style' );
+			wp_enqueue_script( 'frontblocks-stacked-images-frontend' );
+		}
+	}
+
+	/**
+	 * Enqueue block editor assets.
+	 *
+	 * @return void
+	 */
+	public function enqueue_block_editor_assets() {
+		// Enqueue styles for editor.
+		wp_enqueue_style(
+			'frontblocks-stacked-images-style',
+			FRBL_PLUGIN_URL . 'assets/stacked-images/frontblocks-stacked-images.css',
+			array(),
+			FRBL_VERSION
+		);
+
+		wp_enqueue_script(
+			'frontblocks-stacked-images-option',
+			FRBL_PLUGIN_URL . 'assets/stacked-images/frontblocks-stacked-images.js',
+			array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-data', 'wp-editor', 'wp-block-editor', 'wp-compose', 'wp-i18n' ),
+			FRBL_VERSION,
+			true
+		);
+	}
+
+	/**
+	 * Register the Stacked Images block.
+	 *
+	 * @return void
+	 */
+	public function register_stacked_images_block() {
+		$args = array(
+			'editor_script'   => 'frontblocks-stacked-images-option',
+			'render_callback' => array( $this, 'render_stacked_images_block' ),
+			'attributes'      => array(
+				'images'           => array(
+					'type'    => 'array',
+					'default' => array(),
+				),
+				'direction'        => array(
+					'type'    => 'string',
+					'default' => 'bottom',
+				),
+				'animationDuration' => array(
+					'type'    => 'number',
+					'default' => 1000,
+				),
+				'animationDelay'   => array(
+					'type'    => 'number',
+					'default' => 500,
+				),
+				'containerHeight'  => array(
+					'type'    => 'number',
+					'default' => 500,
+				),
+				'className'        => array(
+					'type'    => 'string',
+					'default' => '',
+				),
+			),
+		);
+
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'frontblocks/stacked-images' ) ) {
+			register_block_type(
+				'frontblocks/stacked-images',
+				$args
+			);
+		}
+	}
+
+	/**
+	 * Render the Stacked Images block on frontend.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string HTML output.
+	 */
+	public function render_stacked_images_block( $attributes ) {
+		$images             = $attributes['images'] ?? array();
+		$direction          = sanitize_text_field( $attributes['direction'] ?? 'bottom' );
+		$animation_duration = absint( $attributes['animationDuration'] ?? 1000 );
+		$animation_delay    = absint( $attributes['animationDelay'] ?? 500 );
+		$container_height   = absint( $attributes['containerHeight'] ?? 500 );
+
+		if ( empty( $images ) ) {
+			return '<div class="frbl-stacked-images-placeholder">' . esc_html__( 'Please add images to the Stacked Images block.', 'frontblocks' ) . '</div>';
+		}
+
+		$wrapper_class = 'frbl-stacked-images-wrapper';
+		if ( ! empty( $attributes['className'] ) ) {
+			$wrapper_class .= ' ' . esc_attr( $attributes['className'] );
+		}
+
+		ob_start();
+		?>
+		<div 
+			class="<?php echo esc_attr( $wrapper_class ); ?>" 
+			data-direction="<?php echo esc_attr( $direction ); ?>"
+			data-duration="<?php echo esc_attr( $animation_duration ); ?>"
+			data-delay="<?php echo esc_attr( $animation_delay ); ?>"
+			style="height: <?php echo esc_attr( $container_height ); ?>px;"
+		>
+			<div class="frbl-stacked-images-container">
+				<?php foreach ( $images as $index => $image ) : ?>
+					<?php
+					$image_url = isset( $image['url'] ) ? esc_url( $image['url'] ) : '';
+					$image_alt = isset( $image['alt'] ) ? esc_attr( $image['alt'] ) : '';
+					$image_id  = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
+					?>
+					<div 
+						class="frbl-stacked-image" 
+						data-index="<?php echo esc_attr( $index ); ?>"
+						style="z-index: <?php echo esc_attr( $index + 1 ); ?>;"
+					>
+						<img 
+							src="<?php echo $image_url; ?>" 
+							alt="<?php echo $image_alt; ?>"
+							loading="lazy"
+						/>
+					</div>
+				<?php endforeach; ?>
+			</div>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+}
+
+new StackedImages();

--- a/includes/Plugin_Main.php
+++ b/includes/Plugin_Main.php
@@ -126,6 +126,9 @@ class Plugin_Main {
 
 		// Fluid Typography module (GeneratePress Pro integration).
 		new Frontend\FluidTypography();
+
+		// Stacked Images module.
+		new Frontend\StackedImages();
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "build:post": "babel assets/insert-post/frontblocks-insert-post-option.jsx --out-file assets/insert-post/frontblocks-insert-post-option.js",
     "build:product-categories": "babel assets/product-categories/frontblocks-product-categories-option.jsx --out-file assets/product-categories/frontblocks-product-categories.js",
     "build:reading-time": "babel assets/reading-time/frontblocks-reading-time-option.jsx --out-file assets/reading-time/frontblocks-reading-time.js",
+    "build:stacked-images": "babel assets/stacked-images/frontblocks-stacked-images-option.jsx --out-file assets/stacked-images/frontblocks-stacked-images.js",
     
     "build:edge-alignment": "babel assets/container-edge-alignment/frontblocks-edge-alignment-option.jsx --out-file assets/container-edge-alignment/frontblocks-edge-alignment.js",
     "build:shape-animations": "babel assets/shape-animations/frontblocks-shape-animation-option.jsx --out-file assets/shape-animations/frontblocks-shape-animation-option.js",
@@ -51,7 +52,7 @@
     "build:css": "postcss assets/admin/settings-src.css -o assets/admin/settings.css",
     "watch:css": "postcss assets/admin/settings-src.css -o assets/admin/settings.css --watch",
     
-    "build": "npm run build:carousel && npm run build:animations && npm run build:sticky && npm run build:gallery && npm run build:post && npm run build:headline && npm run build:product-categories && npm run build:reading-time && npm run build:edge-alignment && npm run build:shape-animations && npm run build:gf-inline && npm run build:css"
+    "build": "npm run build:carousel && npm run build:animations && npm run build:sticky && npm run build:gallery && npm run build:post && npm run build:headline && npm run build:product-categories && npm run build:reading-time && npm run build:stacked-images && npm run build:edge-alignment && npm run build:shape-animations && npm run build:gf-inline && npm run build:css"
   },
   "dependencies": {
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary

Introduced a new **Stacked Images** Gutenberg block that displays multiple images with a sequential entrance animation from a configurable direction.

- Registered `frontblocks/stacked-images` as a dynamic (server-side rendered) block via `StackedImages.php`
- Block attributes: `images` (array), `direction` (top/bottom/left/right), `animationDuration`, `animationDelay`, `containerHeight`
- Editor component (`frontblocks-stacked-images-option.jsx`): media library picker, live stacked preview with random rotation, and a settings summary
- Frontend script (`frontblocks-stacked-images-frontend.js`): uses `IntersectionObserver` to trigger sequential fade-in + translate animations when the container scrolls into view; images animate one by one with configurable delay
- Added CSS (`frontblocks-stacked-images.css`) for the wrapper, container, and individual image positioning
- Registered `build:stacked-images` npm script and added the module to the main `build` chain
- Instantiated `StackedImages` in `Plugin_Main::load_modules()`