### PR TITLE
Language recommendation banner

### DIFF
--- a/assets/admin/icons/language-banner.svg
+++ b/assets/admin/icons/language-banner.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <line x1="2" y1="12" x2="22" y2="12"/>
+  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+</svg>

--- a/frontblocks.php
+++ b/frontblocks.php
@@ -3,7 +3,7 @@
  * Plugin Name: FrontBlocks for GeneratePress
  * Plugin URI:  https://wordpress.org/plugins/frontblocks/
  * Description: Blocks and helpers that extends GeneratePress blocks.
- * Version:     1.3.1
+ * Version:     1.4.0-beta.1
  * Author:      Closemarketing
  * Author URI:  https://close.marketing
  * Text Domain: frontblocks
@@ -26,7 +26,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'FRBL_VERSION', '1.3.1' );
+define( 'FRBL_VERSION', '1.4.0-beta.1' );
 define( 'FRBL_PLUGIN', __FILE__ );
 define( 'FRBL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'FRBL_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -139,6 +139,13 @@ class Settings {
 	private $option_enable_fullpage_scroll = 'enable_fullpage_scroll';
 
 	/**
+	 * Option key for language banner feature (PRO).
+	 *
+	 * @var string
+	 */
+	private $option_enable_language_banner = 'enable_language_banner';
+
+	/**
 	 * Page slug.
 	 *
 	 * @var string
@@ -551,6 +558,14 @@ class Settings {
 			'frontblocks_section_woocommerce_features'
 		);
 
+		add_settings_field(
+			$this->option_enable_language_banner,
+			__( 'Enable Language Banner', 'frontblocks' ),
+			array( $this, 'field_enable_language_banner' ),
+			$this->page_slug,
+			'frontblocks_section_woocommerce_features'
+		);
+
 		// Custom Post Types section (PRO).
 		if ( frbl_is_pro_active() ) {
 			add_settings_section(
@@ -909,6 +924,7 @@ class Settings {
 				$this->option_deactivate_product_tabs,
 				$this->option_horizontal_product_form,
 				$this->option_enable_fullpage_scroll,
+				$this->option_enable_language_banner,
 			),
 			true
 		);
@@ -966,6 +982,7 @@ class Settings {
 			$this->option_deactivate_product_tabs      => 'deactivate-tabs',
 			$this->option_horizontal_product_form      => 'horizontal-form',
 			$this->option_enable_fullpage_scroll       => 'fullpage-scroll',
+			$this->option_enable_language_banner       => 'language-banner',
 		);
 
 		$icon_name = $icon_map[ $field_id ] ?? 'default';
@@ -1249,6 +1266,15 @@ class Settings {
 	}
 
 	/**
+	 * Render Enable Language Banner field.
+	 *
+	 * @return void
+	 */
+	public function field_enable_language_banner() {
+		$this->render_pro_toggle( $this->option_enable_language_banner );
+	}
+
+	/**
 	 * Custom Post Types section callback.
 	 *
 	 * @return void
@@ -1485,6 +1511,7 @@ class Settings {
 			$this->option_horizontal_product_form,
 			$this->option_enable_custom_post_types,
 			$this->option_enable_fullpage_scroll,
+			$this->option_enable_language_banner,
 		);
 
 		// Initialize all boolean options to false (unchecked checkboxes are not submitted).


### PR DESCRIPTION
## Summary

Added a **Language Recommendation Banner** option to the FrontBlocks settings page as a PRO feature placeholder.

- Added `$option_enable_language_banner` private property to the `Settings` class
- Registered a new settings field "Enable Language Banner" in the WooCommerce Features section
- Added `field_enable_language_banner()` render method that calls `render_pro_toggle()`
- Added the option to the sanitization and settings field lists
- Added `language-banner.svg` icon to `assets/admin/icons/`
- Bumped plugin version to `1.4.0-beta.1`