### PR TITLE
fix: improve carousel bullet accessibility (aria-label and clickable area)

### DIFF
--- a/assets/carousel/frontblocks-carousel.css
+++ b/assets/carousel/frontblocks-carousel.css
@@ -101,29 +101,33 @@
   display: inline-flex;
   list-style: none;
   transform: translateX(-50%);
-  gap: 5px;
+  gap: 2px;
 }
 .glide__bullet {
   background-color: rgba(255, 255, 255, 0.5);
-  width: 13px;
-  height: 13px;
-  padding: 0;
+  width: 14px;
+  height: 14px;
+  padding: 10px;
   border-radius: 50%;
   border: 2px solid transparent;
+  background-clip: content-box;
   transition: all 300ms ease-in-out;
   cursor: pointer;
   line-height: 0;
   margin: 0;
 }
 .glide__bullet:focus {
-  outline: none;
+  outline: 2px solid white;
+  outline-offset: 2px;
 }
 .glide__bullet:hover, .glide__bullet:focus {
   border: 2px solid white;
   background-color: rgba(255, 255, 255, 0.5);
+  background-clip: content-box;
 }
 .glide__bullet--active {
   background-color: white;
+  background-clip: content-box;
 }
 .glide--swipeable {
   cursor: grab;

--- a/assets/carousel/frontblocks-carousel.js
+++ b/assets/carousel/frontblocks-carousel.js
@@ -63,6 +63,8 @@ window.addEventListener('load', function (event) {
                 const bullets = document.createElement('div');
                 bullets.classList.add('glide__bullets');
                 bullets.setAttribute('data-glide-el', 'controls[nav]');
+                bullets.setAttribute('role', 'group');
+                bullets.setAttribute('aria-label', 'Slide navigation');
 
                 for (let i = 0; i < item.children.length; i++) {
                     const bullet = document.createElement('button');


### PR DESCRIPTION
## Summary

- Add `role="group"` and `aria-label="Slide navigation"` to the bullets container so screen readers can announce the navigation region
- Increase bullet clickable area using `padding: 10px` + `background-clip: content-box`, growing the touch target from 13px to 34×34px while keeping the visual dot small
- Slightly increase bullet visual size from 13px to 14px
- Improve focus visibility: replace `outline: none` with a visible `outline: 2px solid white` + `outline-offset`
- Reduce gap between bullets from 5px to 2px to compensate for the added padding spacing

## Changes

- `assets/carousel/frontblocks-carousel.js` — bullets container now has `role="group"` and `aria-label="Slide navigation"`; individual bullet `aria-label="Go to slide N"` was already present
- `assets/carousel/frontblocks-carousel.css` — increased bullet size, added padding with `background-clip: content-box`, visible focus outline

## Accessibility compliance

The updated touch target (34×34px) meets the **WCAG 2.5.8 Level AA** minimum of 24×24px. The `aria-label` on each bullet and the group label on the container ensure full screen reader compatibility.

## Test plan

- [ ] Verify carousel bullets render correctly visually
- [ ] Verify clickable area is noticeably larger on touch devices
- [ ] Validate with a screen reader (e.g. VoiceOver / NVDA) that bullets are announced as "Go to slide 1", "Go to slide 2", etc., within a "Slide navigation" group
- [ ] Confirm no regression in layout or styling on desktop and mobile
- [ ] Check active bullet color still applies correctly via inline style

Closes #118