### PR TITLE
Implement conditional asset loading for improved performance

### DIFF
--- a/includes/Frontend/Animations.php
+++ b/includes/Frontend/Animations.php
@@ -32,27 +32,26 @@ class Animations {
 	 * @return void
 	 */
 	private function init_hooks() {
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 100 );
+		add_action( 'init', array( $this, 'register_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ), 5 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'register_animation_attributes' ), 15 );
 		add_filter( 'render_block', array( $this, 'add_animation_classes_to_blocks' ), 10, 2 );
 	}
 
 	/**
-	 * Enqueue scripts and styles.
+	 * Register frontend scripts and styles for conditional enqueueing.
 	 *
 	 * @return void
 	 */
-	public function enqueue_scripts() {
-		// Enqueue custom animations CSS.
-		wp_enqueue_style(
+	public function register_scripts() {
+		wp_register_style(
 			'frontblocks-animations',
 			FRBL_PLUGIN_URL . 'assets/animations/frontblocks-animations.css',
 			array(),
 			FRBL_VERSION
 		);
 
-		wp_enqueue_script(
+		wp_register_script(
 			'frontblocks-animations-custom',
 			FRBL_PLUGIN_URL . 'assets/animations/frontblocks-animations.js',
 			array(),
@@ -67,13 +66,8 @@ class Animations {
 	 * @return void
 	 */
 	public function enqueue_block_editor_assets() {
-		// Enqueue custom animations CSS for editor.
-		wp_enqueue_style(
-			'frontblocks-animations-editor',
-			FRBL_PLUGIN_URL . 'assets/animations/frontblocks-animations.css',
-			array(),
-			FRBL_VERSION
-		);
+		// Enqueue custom animations CSS for editor (reuse registered frontend style).
+		wp_enqueue_style( 'frontblocks-animations' );
 
 		// Enqueue custom block editor script.
 		wp_enqueue_script(
@@ -206,6 +200,14 @@ class Animations {
 
 		if ( ! $has_animation && ! $has_glass_effect && ! $has_hover_bg_scale ) {
 			return $block_content;
+		}
+
+		// Enqueue frontend assets only when a block with animation features is present.
+		if ( ! wp_style_is( 'frontblocks-animations', 'enqueued' ) ) {
+			wp_enqueue_style( 'frontblocks-animations' );
+		}
+		if ( ! wp_script_is( 'frontblocks-animations-custom', 'enqueued' ) ) {
+			wp_enqueue_script( 'frontblocks-animations-custom' );
 		}
 
 		$properties = array();

--- a/includes/Frontend/Carousel.php
+++ b/includes/Frontend/Carousel.php
@@ -32,12 +32,37 @@ class Carousel {
 	 * @return void
 	 */
 	private function init_hooks() {
+		add_action( 'init', array( $this, 'register_frontend_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_canvas_assets' ) );
 		add_filter( 'render_block_generateblocks/grid', array( $this, 'add_custom_attributes_to_grid_block' ), 10, 2 );
 		add_filter( 'render_block_generateblocks/element', array( $this, 'add_custom_attributes_to_element_block' ), 10, 2 );
 		add_filter( 'render_block_core/group', array( $this, 'add_custom_attributes_to_core_group_block' ), 10, 2 );
 		add_action( 'init', array( $this, 'register_custom_attributes' ), 5 );
+	}
+
+	/**
+	 * Register frontend carousel assets for conditional enqueueing.
+	 *
+	 * @return void
+	 */
+	public function register_frontend_assets() {
+		// Assets are registered in Plugin_Main::register_scripts().
+		// This method exists as a hook point for any additional registration needs.
+	}
+
+	/**
+	 * Enqueue carousel frontend assets when a carousel block is detected.
+	 *
+	 * @return void
+	 */
+	private function enqueue_carousel_assets() {
+		if ( ! wp_style_is( 'frontblocks-carousel', 'enqueued' ) ) {
+			wp_enqueue_style( 'frontblocks-carousel' );
+		}
+		if ( ! wp_script_is( 'frontblocks-carousel-custom', 'enqueued' ) ) {
+			wp_enqueue_script( 'frontblocks-carousel-custom' );
+		}
 	}
 
 	/**
@@ -129,6 +154,8 @@ class Carousel {
 				$block_content,
 				1 // Only replace the first occurrence.
 			);
+
+			$this->enqueue_carousel_assets();
 		}
 
 		return $block_content;
@@ -195,6 +222,8 @@ class Carousel {
 				$block_content,
 				1 // Only replace the first occurrence.
 			);
+
+			$this->enqueue_carousel_assets();
 		}
 
 		return $block_content;
@@ -261,6 +290,8 @@ class Carousel {
 				$block_content,
 				1 // Only replace the first occurrence.
 			);
+
+			$this->enqueue_carousel_assets();
 		}
 
 		return $block_content;

--- a/includes/Frontend/ContainerEdgeAlignment.php
+++ b/includes/Frontend/ContainerEdgeAlignment.php
@@ -25,8 +25,8 @@ class ContainerEdgeAlignment {
 	 * Constructor.
 	 */
 	public function __construct() {
+		add_action( 'init', array( $this, 'register_frontend_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
 		add_filter( 'render_block', array( $this, 'add_edge_alignment_classes' ), 10, 2 );
 	}
 
@@ -59,20 +59,19 @@ class ContainerEdgeAlignment {
 	}
 
 	/**
-	 * Enqueue frontend assets.
+	 * Register frontend assets for conditional enqueueing.
 	 *
 	 * @return void
 	 */
-	public function enqueue_frontend_assets() {
-		wp_enqueue_style(
+	public function register_frontend_assets() {
+		wp_register_style(
 			'frbl-edge-alignment',
 			FRBL_PLUGIN_URL . 'assets/container-edge-alignment/frontblocks-edge-alignment.css',
 			array(),
 			FRBL_VERSION
 		);
 
-		// Add inline script to calculate margins dynamically.
-		wp_enqueue_script(
+		wp_register_script(
 			'frbl-edge-alignment-js',
 			FRBL_PLUGIN_URL . 'assets/container-edge-alignment/frontblocks-edge-alignment-frontend.js',
 			array(),
@@ -114,6 +113,14 @@ class ContainerEdgeAlignment {
 		// If no valid alignment, return.
 		if ( empty( $class_string ) ) {
 			return $block_content;
+		}
+
+		// Enqueue frontend assets only when an edge-aligned block is detected.
+		if ( ! wp_style_is( 'frbl-edge-alignment', 'enqueued' ) ) {
+			wp_enqueue_style( 'frbl-edge-alignment' );
+		}
+		if ( ! wp_script_is( 'frbl-edge-alignment-js', 'enqueued' ) ) {
+			wp_enqueue_script( 'frbl-edge-alignment-js' );
 		}
 
 		// Add class to the block.

--- a/includes/Frontend/Counter.php
+++ b/includes/Frontend/Counter.php
@@ -23,7 +23,6 @@ class Counter {
 		add_action( 'init', array( $this, 'register_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
 		add_filter( 'render_block', array( $this, 'render_block_counter' ), 10, 2 );
-		add_action( 'wp_footer', array( $this, 'enqueue_counter_script' ) );
 	}
 
 	/**
@@ -96,6 +95,7 @@ class Counter {
 		$number_suffix      = isset( $attrs['numberSuffix'] ) ? $attrs['numberSuffix'] : '';
 
 		if ( $is_counter_active ) {
+			$this->enqueue_counter_script();
 			$class_to_add      = 'frontblocks-counter-active';
 			$target_value_full = '';
 

--- a/includes/Frontend/GravityFormsInline.php
+++ b/includes/Frontend/GravityFormsInline.php
@@ -34,26 +34,26 @@ class GravityFormsInline {
 	 * @return void
 	 */
 	private function init_hooks() {
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 99 );
+		add_action( 'init', array( $this, 'register_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'render_block', array( $this, 'add_inline_attributes_to_gf_block' ), 10, 2 );
 		add_action( 'init', array( $this, 'register_custom_attributes' ), 5 );
 	}
 
 	/**
-	 * Enqueue scripts and styles.
+	 * Register frontend scripts and styles for conditional enqueueing.
 	 *
 	 * @return void
 	 */
-	public function enqueue_scripts() {
-		wp_enqueue_style(
+	public function register_scripts() {
+		wp_register_style(
 			'frontblocks-gf-inline',
 			FRBL_PLUGIN_URL . 'assets/gravityforms-inline/frontblocks-gf-inline.css',
 			array(),
 			FRBL_VERSION
 		);
 
-		wp_enqueue_script(
+		wp_register_script(
 			'frontblocks-gf-inline-runtime',
 			FRBL_PLUGIN_URL . 'assets/gravityforms-inline/frontblocks-gf-inline.js',
 			array(),
@@ -110,6 +110,13 @@ class GravityFormsInline {
 
 		// Add inline class and attributes if enabled.
 		if ( $inline_enabled ) {
+			// Enqueue frontend assets only when the GF inline feature is active.
+			if ( ! wp_style_is( 'frontblocks-gf-inline', 'enqueued' ) ) {
+				wp_enqueue_style( 'frontblocks-gf-inline' );
+			}
+			if ( ! wp_script_is( 'frontblocks-gf-inline-runtime', 'enqueued' ) ) {
+				wp_enqueue_script( 'frontblocks-gf-inline-runtime' );
+			}
 			// Try multiple approaches to add the class.
 			// Method 1: Add to wp-block-gravityforms-form wrapper.
 			if ( strpos( $block_content, 'wp-block-gravityforms-form' ) !== false ) {

--- a/includes/Frontend/Headline.php
+++ b/includes/Frontend/Headline.php
@@ -24,9 +24,10 @@ class Headline {
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_styles' ), 100 );
 		add_filter( 'generateblocks_attr_headline', array( $this, 'add_line_class_attribute' ), 10 );
 		add_filter( 'generateblocks_attr_text', array( $this, 'add_marquee_speed_attribute' ), 10, 2 );
+		add_filter( 'render_block_generateblocks/text', array( $this, 'maybe_enqueue_frontend_assets' ), 10, 2 );
+		add_filter( 'render_block_generateblocks/headline', array( $this, 'maybe_enqueue_frontend_assets' ), 10, 2 );
 	}
 
 	/**
@@ -84,13 +85,26 @@ class Headline {
 	}
 
 	/**
-	 * Enqueue frontend styles and scripts.
+	 * Conditionally enqueue frontend assets when a GenerateBlocks headline/text block is rendered.
 	 *
-	 * @return void
+	 * @param string $block_content Block content.
+	 * @param array  $block         Block data.
+	 * @return string
 	 */
-	public function enqueue_frontend_styles() {
-		wp_enqueue_style( 'frontblocks-headline-styles' );
-		wp_enqueue_script( 'frontblocks-headline-marquee' );
+	public function maybe_enqueue_frontend_assets( $block_content, $block ) {
+		$attrs = $block['attrs'] ?? array();
+
+		// Enqueue headline styles when any headline/text block with frbl features is rendered.
+		if ( ! wp_style_is( 'frontblocks-headline-styles', 'enqueued' ) ) {
+			wp_enqueue_style( 'frontblocks-headline-styles' );
+		}
+
+		// Enqueue marquee script only when marquee is active on this block.
+		if ( ! empty( $attrs['frblMarqueeSpeed'] ) && ! wp_script_is( 'frontblocks-headline-marquee', 'enqueued' ) ) {
+			wp_enqueue_script( 'frontblocks-headline-marquee' );
+		}
+
+		return $block_content;
 	}
 
 	/**

--- a/includes/Frontend/InsertPost.php
+++ b/includes/Frontend/InsertPost.php
@@ -32,7 +32,7 @@ class InsertPost {
 	 * @return void
 	 */
 	private function init_hooks() {
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 99 );
+		add_action( 'init', array( $this, 'register_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_action( 'wp_ajax_frbl_search_posts', array( $this, 'search_posts_callback' ) );
 		add_action( 'wp_ajax_nopriv_frbl_search_posts', array( $this, 'search_posts_callback' ) );
@@ -42,12 +42,12 @@ class InsertPost {
 	}
 
 	/**
-	 * Enqueue scripts and styles.
+	 * Register frontend scripts and styles for conditional enqueueing.
 	 *
 	 * @return void
 	 */
-	public function enqueue_scripts() {
-		wp_enqueue_style(
+	public function register_scripts() {
+		wp_register_style(
 			'frontblocks-insert-post',
 			FRBL_PLUGIN_URL . 'assets/insert-post/frontblocks-insert-post.css',
 			array(),
@@ -180,6 +180,11 @@ class InsertPost {
 	 * @return string HTML output.
 	 */
 	public function render_insert_post_block( $attributes ) {
+		// Enqueue frontend styles only when this block is rendered.
+		if ( ! wp_style_is( 'frontblocks-insert-post', 'enqueued' ) ) {
+			wp_enqueue_style( 'frontblocks-insert-post' );
+		}
+
 		$post_id = $attributes['selectedPostId'] ?? 0;
 
 		if ( ! $post_id ) {

--- a/includes/Frontend/ShapeAnimations.php
+++ b/includes/Frontend/ShapeAnimations.php
@@ -34,27 +34,27 @@ class ShapeAnimations {
 	 * @return void
 	 */
 	private function init_hooks() {
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 100 );
+		add_action( 'init', array( $this, 'register_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ), 5 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'register_shape_animation_attributes' ), 15 );
 		add_filter( 'render_block', array( $this, 'add_animation_classes_to_shape' ), 10, 2 );
 	}
 
 	/**
-	 * Enqueue frontend scripts and styles.
+	 * Register frontend scripts and styles for conditional enqueueing.
 	 *
 	 * @return void
 	 */
-	public function enqueue_scripts() {
-		wp_enqueue_style(
+	public function register_scripts() {
+		wp_register_style(
 			'frontblocks-shape-animations',
 			FRBL_PLUGIN_URL . 'assets/shape-animations/frontblocks-shape-animations.css',
 			array(),
 			FRBL_VERSION
 		);
 
-		// Enqueue Lottie library from CDN.
-		wp_enqueue_script(
+		// Register Lottie library from CDN.
+		wp_register_script(
 			'lottie-player',
 			'https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js',
 			array(),
@@ -62,7 +62,7 @@ class ShapeAnimations {
 			true
 		);
 
-		wp_enqueue_script(
+		wp_register_script(
 			'frontblocks-shape-animations',
 			FRBL_PLUGIN_URL . 'assets/shape-animations/frontblocks-shape-animations.js',
 			array( 'lottie-player' ),
@@ -181,6 +181,14 @@ class ShapeAnimations {
 
 		if ( empty( $attrs['frblCustomSvgAnimationJson'] ) ) {
 			return $block_content;
+		}
+
+		// Enqueue frontend assets only when a shape animation block is detected.
+		if ( ! wp_style_is( 'frontblocks-shape-animations', 'enqueued' ) ) {
+			wp_enqueue_style( 'frontblocks-shape-animations' );
+		}
+		if ( ! wp_script_is( 'frontblocks-shape-animations', 'enqueued' ) ) {
+			wp_enqueue_script( 'frontblocks-shape-animations' );
 		}
 
 		// Parse JSON data.

--- a/includes/Frontend/StickyColumn.php
+++ b/includes/Frontend/StickyColumn.php
@@ -32,27 +32,26 @@ class StickyColumn {
 	 * @return void
 	 */
 	private function init_hooks() {
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 99 );
+		add_action( 'init', array( $this, 'register_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'render_block_generateblocks/grid', array( $this, 'add_sticky_attributes_to_grid_block' ), 10, 2 );
 		add_action( 'init', array( $this, 'register_custom_attributes' ), 5 );
 	}
 
 	/**
-	 * Enqueue scripts and styles.
+	 * Register frontend scripts and styles for conditional enqueueing.
 	 *
 	 * @return void
 	 */
-	public function enqueue_scripts() {
-
-		wp_enqueue_style(
+	public function register_scripts() {
+		wp_register_style(
 			'frontblocks-sticky-column',
 			FRBL_PLUGIN_URL . 'assets/sticky-column/frontblocks-sticky-column.css',
 			array(),
 			FRBL_VERSION
 		);
 
-		wp_enqueue_script(
+		wp_register_script(
 			'frontblocks-sticky-column-custom',
 			FRBL_PLUGIN_URL . 'assets/sticky-column/frontblocks-sticky-column.js',
 			array(),
@@ -107,6 +106,14 @@ class StickyColumn {
 				$block_content,
 				1 // Only replace the first occurrence.
 			);
+
+			// Enqueue frontend assets only when a sticky column block is detected.
+			if ( ! wp_style_is( 'frontblocks-sticky-column', 'enqueued' ) ) {
+				wp_enqueue_style( 'frontblocks-sticky-column' );
+			}
+			if ( ! wp_script_is( 'frontblocks-sticky-column-custom', 'enqueued' ) ) {
+				wp_enqueue_script( 'frontblocks-sticky-column-custom' );
+			}
 		}
 
 		return $block_content;

--- a/includes/Plugin_Main.php
+++ b/includes/Plugin_Main.php
@@ -54,8 +54,10 @@ class Plugin_Main {
 		// Load modules.
 		$this->load_modules();
 
-		// General enqueue scripts.
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 99 );
+		// Register scripts for conditional enqueueing.
+		add_action( 'init', array( $this, 'register_scripts' ) );
+		// Conditionally enqueue accordion script when an accordion block is rendered.
+		add_filter( 'render_block', array( $this, 'maybe_enqueue_accordion_script' ), 10, 2 );
 	}
 
 	/**
@@ -135,27 +137,19 @@ class Plugin_Main {
 	}
 
 	/**
-	 * Enqueue scripts.
+	 * Register scripts for conditional enqueueing.
 	 *
 	 * @return void
 	 */
-	public function enqueue_scripts() {
-		wp_enqueue_style(
+	public function register_scripts() {
+		wp_register_style(
 			'frontblocks-carousel',
 			FRBL_PLUGIN_URL . 'assets/carousel/frontblocks-carousel.css',
 			array(),
 			FRBL_VERSION
 		);
 
-		wp_enqueue_script(
-			'frontblocks-carousel-custom',
-			FRBL_PLUGIN_URL . 'assets/carousel/frontblocks-carousel.js',
-			array( 'frontblocks-carousel' ),
-			FRBL_VERSION,
-			true
-		);
-
-		wp_enqueue_script(
+		wp_register_script(
 			'frontblocks-carousel',
 			FRBL_PLUGIN_URL . 'assets/carousel/glide.min.js',
 			array(),
@@ -163,13 +157,42 @@ class Plugin_Main {
 			true
 		);
 
-		// GenerateBlocks Accordion fix – ensures accordions work when FrontBlocks is active.
-		wp_enqueue_script(
+		wp_register_script(
+			'frontblocks-carousel-custom',
+			FRBL_PLUGIN_URL . 'assets/carousel/frontblocks-carousel.js',
+			array( 'frontblocks-carousel' ),
+			FRBL_VERSION,
+			true
+		);
+
+		// GenerateBlocks Accordion fix – registers script for conditional enqueueing.
+		wp_register_script(
 			'frontblocks-accordion',
 			FRBL_PLUGIN_URL . 'assets/accordion/frontblocks-accordion.js',
 			array(),
 			FRBL_VERSION,
 			true
 		);
+	}
+
+	/**
+	 * Enqueue accordion script only when an accordion block is present on the page.
+	 *
+	 * @param string $block_content Block content.
+	 * @param array  $block         Block data.
+	 * @return string
+	 */
+	public function maybe_enqueue_accordion_script( $block_content, $block ) {
+		if ( ! isset( $block['blockName'] ) ) {
+			return $block_content;
+		}
+
+		if ( false !== strpos( $block['blockName'], 'accordion' ) ) {
+			if ( ! wp_script_is( 'frontblocks-accordion', 'enqueued' ) ) {
+				wp_enqueue_script( 'frontblocks-accordion' );
+			}
+		}
+
+		return $block_content;
 	}
 }


### PR DESCRIPTION
## Summary
This PR refactors the plugin's asset loading strategy from unconditional enqueueing to conditional loading. Assets are now registered on the `init` hook and only enqueued when their corresponding blocks are actually rendered on the page, reducing unnecessary script and style loading.

## Key Changes

- **Plugin_Main.php**: Changed from unconditional script enqueueing to conditional loading via `render_block` filter for accordion scripts
- **Carousel.php**: Added `register_frontend_assets()` method and conditional enqueueing in block render filters; assets now load only when carousel blocks are detected
- **Animations.php**: Converted `enqueue_scripts()` to `register_scripts()` using `wp_register_*` functions; added conditional enqueueing in `add_animation_classes_to_blocks()` filter
- **Headline.php**: Replaced `wp_enqueue_scripts` hook with `render_block` filters for headline/text blocks; marquee script now only loads when marquee feature is active
- **ShapeAnimations.php**: Changed to registration pattern with conditional enqueueing in `add_animation_classes_to_shape()` filter
- **ContainerEdgeAlignment.php**: Converted to registration pattern with conditional enqueueing in `add_edge_alignment_classes()` filter
- **StickyColumn.php**: Changed to registration pattern with conditional enqueueing in `add_sticky_attributes_to_grid_block()` filter
- **GravityFormsInline.php**: Converted to registration pattern with conditional enqueueing when inline feature is active
- **InsertPost.php**: Changed to registration pattern with conditional enqueueing in `render_insert_post_block()` callback

## Implementation Details

- All frontend assets are now registered during the `init` hook using `wp_register_style()` and `wp_register_script()`
- Assets are conditionally enqueued using `render_block` filters or block render callbacks when their corresponding blocks are detected
- Prevents duplicate enqueueing by checking `wp_style_is()` and `wp_script_is()` before enqueueing
- Maintains backward compatibility while reducing page load impact for pages that don't use specific features

https://claude.ai/code/session_01HViCm5WRkqZFKcKRrkJRZN