### PR TITLE
Move settings to appeareance child

### DIFF
--- a/frontblocks.php
+++ b/frontblocks.php
@@ -58,7 +58,7 @@ function frbl_plugin_activation_redirect() {
 	// Redirect to settings page.
 	if ( get_option( 'frbl_activation_redirect', false ) ) {
 		delete_option( 'frbl_activation_redirect' );
-		wp_safe_redirect( admin_url( 'admin.php?page=frontblocks-settings' ) );
+		wp_safe_redirect( admin_url( 'themes.php?page=frontblocks-settings' ) );
 		exit;
 	}
 }

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -198,7 +198,7 @@ class Settings {
 	 * @return void
 	 */
 	public function enqueue_admin_styles( $hook ) {
-		if ( 'toplevel_page_' . $this->page_slug !== $hook ) {
+		if ( 'appearance_page_' . $this->page_slug !== $hook ) {
 			return;
 		}
 
@@ -382,19 +382,12 @@ class Settings {
 	 * @return void
 	 */
 	public function register_menu() {
-		// Use SVG icon if available, otherwise fallback to dashicon.
-		$icon_url  = FRBL_PLUGIN_URL . 'assets/admin/icons/icon-menu.svg';
-		$icon_path = FRBL_PLUGIN_PATH . 'assets/admin/icons/icon-menu.svg';
-		$menu_icon = file_exists( $icon_path ) ? $icon_url : 'dashicons-block-default';
-
-		add_menu_page(
+		add_theme_page(
 			__( 'FrontBlocks Settings', 'frontblocks' ),
 			__( 'FrontBlocks', 'frontblocks' ),
 			'edit_theme_options',
 			$this->page_slug,
-			array( $this, 'render_page' ),
-			$menu_icon,
-			81
+			array( $this, 'render_page' )
 		);
 	}
 


### PR DESCRIPTION
## Summary

Moved the FrontBlocks settings page from the top-level admin menu into the **Appearance** submenu.

- Replaced `add_menu_page()` with `add_theme_page()` in `Settings::register_menu()`
- Updated the activation redirect URL from `admin.php?page=frontblocks-settings` to `themes.php?page=frontblocks-settings`
- Updated the hook check in `enqueue_admin_styles()` from `toplevel_page_` to `appearance_page_` prefix
- Removed the SVG menu icon logic (no longer needed for a submenu item)