### PR TITLE
Add WordPress Playground preview automation for pull requests

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -147,10 +147,7 @@ jobs:
               `| **Plugin artifact** | [Download built ZIP ↗](${artifactUrl}) *(GitHub login required · expires in 7 days)* |`,
               ``,
               `> Installs Frontblocks from branch \`${branch}\` and opens the block editor ready to test.`,
-              `> GenerateBlocks is also pre-installed to test Accordion compatibility.`,
-              ``,
-              `---`,
-              `*Auto-generated · [View run](${artifactUrl})*`
+              `> GenerateBlocks is also pre-installed to test Accordion compatibility.`
             ].join('\n');
 
             // Remove previous bot preview comments to avoid clutter

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -34,6 +34,11 @@ jobs:
           php-version: '8.1'
           extensions: mbstring, xml, zip
 
+      - name: Install Composer
+        run: |
+          curl -sS https://getcomposer.org/installer | php
+          sudo mv composer.phar /usr/local/bin/composer
+
       - name: Install Composer dependencies
         run: composer install --no-dev --optimize-autoloader --ignore-platform-reqs
 

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -142,7 +142,7 @@ jobs:
               ``,
               `| | |`,
               `|---|---|`,
-              `| **Live preview** | [Open in WordPress Playground ↗](${playgroundUrl}) |`,
+              `| **Live preview** | <a href="${playgroundUrl}" target="_blank" rel="noopener noreferrer">Open in WordPress Playground ↗</a> |`,
               `| **Credentials** | Username: \`admin\` · Password: \`password\` |`,
               `| **Plugin artifact** | [Download built ZIP ↗](${artifactUrl}) *(GitHub login required · expires in 7 days)* |`,
               ``,

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,0 +1,171 @@
+name: WordPress Playground Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  playground-preview:
+    name: Generate Playground Preview
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build JS assets
+        run: npm run build
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: mbstring, xml, zip
+
+      - name: Install Composer dependencies
+        run: composer install --no-dev --optimize-autoloader --ignore-platform-reqs
+
+      - name: Create plugin ZIP
+        run: |
+          mkdir -p /tmp/plugin/frontblocks
+          rsync -a \
+            --exclude='.git' \
+            --exclude='node_modules' \
+            --exclude='.github' \
+            --exclude='.wordpress-playground' \
+            --exclude='tests' \
+            --exclude='docs' \
+            --exclude='*.jsx' \
+            --exclude='phpcs.xml.dist' \
+            --exclude='phpstan.neon.dist' \
+            --exclude='package.json' \
+            --exclude='package-lock.json' \
+            --exclude='composer.json' \
+            --exclude='composer.lock' \
+            --exclude='tailwind.config.js' \
+            --exclude='postcss.config.js' \
+            --exclude='vendor/squizlabs' \
+            --exclude='vendor/phpcompatibility' \
+            --exclude='vendor/sirbrillig' \
+            --exclude='vendor/wp-coding-standards' \
+            --exclude='vendor/phpcsstandards' \
+            --exclude='vendor/phpunit' \
+            --exclude='vendor/yoast' \
+            --exclude='vendor/phpstan' \
+            --exclude='vendor/szepeviktor' \
+            ./ /tmp/plugin/frontblocks/
+          cd /tmp/plugin
+          zip -r frontblocks.zip frontblocks/
+          echo "Plugin ZIP size: $(du -sh frontblocks.zip | cut -f1)"
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontblocks-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          path: /tmp/plugin/frontblocks.zip
+          retention-days: 7
+
+      - name: Post Playground preview comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const branch = context.payload.pull_request.head.ref;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runId = context.runId;
+
+            const blueprint = {
+              "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+              "landingPage": "/wp-admin/post-new.php",
+              "login": true,
+              "preferredVersions": {
+                "php": "8.1",
+                "wp": "latest"
+              },
+              "steps": [
+                {
+                  "step": "login",
+                  "username": "admin",
+                  "password": "password"
+                },
+                {
+                  "step": "installPlugin",
+                  "pluginZipFile": {
+                    "resource": "url",
+                    "url": `https://github.com/${owner}/${repo}/archive/refs/heads/${branch}.zip`
+                  },
+                  "options": {
+                    "activate": true
+                  }
+                },
+                {
+                  "step": "installPlugin",
+                  "pluginZipFile": {
+                    "resource": "wordpress.org/plugins",
+                    "slug": "generateblocks"
+                  },
+                  "options": {
+                    "activate": true
+                  }
+                }
+              ]
+            };
+
+            const encoded = Buffer.from(JSON.stringify(blueprint)).toString('base64');
+            const playgroundUrl = `https://playground.wordpress.net/#${encoded}`;
+            const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+
+            const body = [
+              `## 🎮 WordPress Playground Preview`,
+              ``,
+              `A live preview of this pull request is available via **WordPress Playground** — no local setup needed.`,
+              ``,
+              `| | |`,
+              `|---|---|`,
+              `| **Live preview** | [Open in WordPress Playground ↗](${playgroundUrl}) |`,
+              `| **Credentials** | Username: \`admin\` · Password: \`password\` |`,
+              `| **Plugin artifact** | [Download built ZIP ↗](${artifactUrl}) *(GitHub login required · expires in 7 days)* |`,
+              ``,
+              `> Installs Frontblocks from branch \`${branch}\` and opens the block editor ready to test.`,
+              `> GenerateBlocks is also pre-installed to test Accordion compatibility.`,
+              ``,
+              `---`,
+              `*Auto-generated · [View run](${artifactUrl})*`
+            ].join('\n');
+
+            // Remove previous bot preview comments to avoid clutter
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber
+            });
+
+            for (const comment of comments) {
+              if (comment.user.type === 'Bot' && comment.body.includes('WordPress Playground Preview')) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: comment.id
+                });
+              }
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body
+            });

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -43,8 +43,10 @@ jobs:
         run: composer install --no-dev --optimize-autoloader --ignore-platform-reqs
 
       - name: Create plugin ZIP
+        env:
+          SLUG: ${{ github.event.repository.name }}
         run: |
-          mkdir -p /tmp/plugin/frontblocks
+          mkdir -p /tmp/plugin/$SLUG
           rsync -a \
             --exclude='.git' \
             --exclude='node_modules' \
@@ -70,16 +72,16 @@ jobs:
             --exclude='vendor/yoast' \
             --exclude='vendor/phpstan' \
             --exclude='vendor/szepeviktor' \
-            ./ /tmp/plugin/frontblocks/
+            ./ /tmp/plugin/$SLUG/
           cd /tmp/plugin
-          zip -r frontblocks.zip frontblocks/
-          echo "Plugin ZIP size: $(du -sh frontblocks.zip | cut -f1)"
+          zip -r $SLUG.zip $SLUG/
+          echo "Plugin ZIP size: $(du -sh $SLUG.zip | cut -f1)"
 
       - name: Upload plugin artifact
         uses: actions/upload-artifact@v4
         with:
-          name: frontblocks-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
-          path: /tmp/plugin/frontblocks.zip
+          name: ${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          path: /tmp/plugin/${{ github.event.repository.name }}.zip
           retention-days: 7
 
       - name: Post Playground preview comment

--- a/.wordpress-playground/blueprint.json
+++ b/.wordpress-playground/blueprint.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/wp-admin/post-new.php",
+  "login": true,
+  "preferredVersions": {
+    "php": "8.1",
+    "wp": "latest"
+  },
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin",
+      "password": "password"
+    },
+    {
+      "step": "installPlugin",
+      "pluginZipFile": {
+        "resource": "wordpress.org/plugins",
+        "slug": "frontblocks"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginZipFile": {
+        "resource": "wordpress.org/plugins",
+        "slug": "generateblocks"
+      },
+      "options": {
+        "activate": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR adds automated WordPress Playground preview generation for pull requests, enabling reviewers and testers to instantly preview changes in a live WordPress environment without local setup.

## Key Changes
- **GitHub Actions Workflow** (`.github/workflows/playground-preview.yml`): New CI/CD workflow that:
  - Builds JavaScript assets and installs PHP dependencies
  - Creates an optimized plugin ZIP file excluding development files and dependencies
  - Generates a WordPress Playground blueprint with base64 encoding
  - Posts an interactive comment on PRs with a direct link to the live preview
  - Automatically cleans up previous bot comments to reduce clutter

- **Playground Blueprint** (`.wordpress-playground/blueprint.json`): Configuration file for local Playground setup that:
  - Configures PHP 8.1 and latest WordPress
  - Auto-logs in with test credentials
  - Pre-installs Frontblocks and GenerateBlocks plugins
  - Opens the block editor for immediate testing

## Implementation Details
- The workflow triggers on PR open, synchronize, and reopen events
- Plugin ZIP creation uses `rsync` with extensive exclusions to minimize artifact size (removes node_modules, vendor, tests, docs, config files, etc.)
- The Playground preview comment includes:
  - Direct link to live preview environment
  - Test credentials (admin/password)
  - Link to built artifact download
  - Branch reference and auto-generated footer
- Previous preview comments are automatically deleted to keep PR discussions clean
- Artifacts are retained for 7 days for manual download if needed
