### PR TITLE
Query loop slider

### DIFF
--- a/assets/carousel/frontblocks-advanced-option.js
+++ b/assets/carousel/frontblocks-advanced-option.js
@@ -78,11 +78,14 @@ function findGridEl(blockEl, name) {
     // Walk up to 4 levels deep to find where the child blocks live.
     return findSlidesParent(blockEl, 4) || blockEl;
   }
+  if (name === 'core/query') {
+    return blockEl.querySelector('.wp-block-post-template') || null;
+  }
   return null;
 }
 function addCustomCarouselPanel(BlockEdit) {
   return function (props) {
-    if (props.name !== 'generateblocks/grid' && props.name !== 'generateblocks/element' && props.name !== 'core/group') {
+    if (props.name !== 'generateblocks/grid' && props.name !== 'generateblocks/element' && props.name !== 'core/group' && props.name !== 'core/query') {
       return /*#__PURE__*/React.createElement(BlockEdit, props);
     }
     if (props.name === 'generateblocks/element') {

--- a/assets/carousel/frontblocks-advanced-option.js
+++ b/assets/carousel/frontblocks-advanced-option.js
@@ -158,12 +158,18 @@ function addCustomCarouselPanel(BlockEdit) {
 
         // Restore gridEl styles.
         try {
+          var preventScroll = stateRef.current.preventScroll;
+          if (preventScroll) {
+            gridEl.removeEventListener('wheel', preventScroll);
+            gridEl.removeEventListener('touchstart', preventScroll);
+            gridEl.removeEventListener('touchmove', preventScroll);
+          }
           gridEl.classList.remove('frbl-carousel-noscrollbar');
-          ['display', 'flex-wrap', 'gap', 'overflow-x', 'scroll-behavior', 'padding-left', 'padding-right'].forEach(function (p) {
+          ['display', 'flex-wrap', 'gap', 'overflow-x', 'scroll-behavior', 'padding-left', 'padding-right', 'max-width', 'grid-template-columns'].forEach(function (p) {
             return gridEl.style.removeProperty(p);
           });
           slides.forEach(function (slide) {
-            ['flex-shrink', 'width', 'min-width', 'margin-left', 'margin-right', 'grid-column'].forEach(function (p) {
+            ['flex-shrink', 'width', 'min-width', 'margin-left', 'margin-right', 'grid-column', 'grid-row'].forEach(function (p) {
               return slide.style.removeProperty(p);
             });
           });
@@ -185,8 +191,12 @@ function addCustomCarouselPanel(BlockEdit) {
         var gridEl = findGridEl(blockEl, props.name);
         if (!gridEl) return;
 
-        // Slides = direct children that are real blocks (UUID data-block).
-        var slides = Array.from(gridEl.children).filter(function (el) {
+        // For core/query, <li> items don't have data-block UUIDs (server-rendered).
+        // For other blocks, filter by UUID data-block attribute.
+        var isQueryLoop = props.name === 'core/query';
+        var slides = isQueryLoop ? Array.from(gridEl.children).filter(function (el) {
+          return el.tagName === 'LI';
+        }) : Array.from(gridEl.children).filter(function (el) {
           return UUID_RE.test(el.dataset.block || '');
         });
         if (slides.length === 0) return;
@@ -194,6 +204,16 @@ function addCustomCarouselPanel(BlockEdit) {
         var gap = Math.max(0, parseInt(frblGap) || 20);
         var btnColor = frblButtonColor || '#fff';
         var btnBg = frblButtonBgColor || 'rgba(0,0,0,0.45)';
+
+        // For core/query, force flex via setProperty to beat WP's grid CSS.
+        if (isQueryLoop) {
+          gridEl.style.setProperty('display', 'flex', 'important');
+          gridEl.style.setProperty('flex-wrap', 'nowrap', 'important');
+          gridEl.style.setProperty('max-width', 'none', 'important');
+          gridEl.style.setProperty('grid-template-columns', 'none', 'important');
+          gridEl.style.setProperty('list-style', 'none', 'important');
+          gridEl.style.setProperty('padding-left', '0', 'important');
+        }
 
         // Measure content-box width before any style changes.
         var editorWin = editorDoc.defaultView || window;
@@ -209,15 +229,17 @@ function addCustomCarouselPanel(BlockEdit) {
         // ── Apply scroll-based layout directly to gridEl ─────────────
         // No DOM restructuring → no React reconciliation conflicts.
         gridEl.classList.add('frbl-carousel-noscrollbar');
-        gridEl.style.display = 'flex';
-        gridEl.style.flexWrap = 'nowrap';
+        if (!isQueryLoop) {
+          gridEl.style.display = 'flex';
+          gridEl.style.flexWrap = 'nowrap';
+          gridEl.style.paddingLeft = ARROW_W + 'px';
+        } else {
+          // paddingLeft already set via setProperty above; override with arrow offset.
+          gridEl.style.setProperty('padding-left', ARROW_W + 'px', 'important');
+        }
         gridEl.style.gap = gap + 'px';
         gridEl.style.overflowX = 'scroll';
         gridEl.style.scrollBehavior = 'smooth';
-        // paddingLeft creates left space for the prev arrow.
-        // paddingRight is NOT used because Chrome ignores it in scroll extent;
-        // a spacer flex child is appended instead to guarantee right-side space.
-        gridEl.style.paddingLeft = ARROW_W + 'px';
         gridEl.style.paddingRight = '0';
         slides.forEach(function (slide) {
           slide.style.flexShrink = '0';
@@ -226,6 +248,7 @@ function addCustomCarouselPanel(BlockEdit) {
           slide.style.marginLeft = '0';
           slide.style.marginRight = '0';
           slide.style.gridColumn = 'unset';
+          slide.style.gridRow = 'unset';
         });
 
         // Right-side spacer: Chrome does not include padding-right in horizontal
@@ -236,12 +259,26 @@ function addCustomCarouselPanel(BlockEdit) {
         spacer.style.cssText = "display:block;flex-shrink:0;width:".concat(ARROW_W, "px;min-width:").concat(ARROW_W, "px;");
         gridEl.insertBefore(spacer, appender || null);
 
-        // ── Navigation (scrollLeft, infinite loop) ───────────────────
+        // Prevent manual scroll — only arrows drive navigation.
+        var preventScroll = function preventScroll(e) {
+          return e.preventDefault();
+        };
+        gridEl.addEventListener('wheel', preventScroll, {
+          passive: false
+        });
+        gridEl.addEventListener('touchstart', preventScroll, {
+          passive: false
+        });
+        gridEl.addEventListener('touchmove', preventScroll, {
+          passive: false
+        });
+
+        // ── Navigation (scrollLeft, item-by-item) ────────────────────
         var idx = 0;
+        var lastIdx = Math.max(0, slides.length - perView);
         function scrollTo(n) {
-          var total = slides.length;
-          if (n >= total) {
-            // Forward past last: instant snap to 0 then continue.
+          if (n > lastIdx) {
+            // Wrap forward to start.
             gridEl.style.scrollBehavior = 'auto';
             gridEl.scrollLeft = 0;
             void gridEl.offsetWidth;
@@ -250,12 +287,12 @@ function addCustomCarouselPanel(BlockEdit) {
             return;
           }
           if (n < 0) {
-            // Back past first: instant snap to last.
+            // Wrap back to end.
             gridEl.style.scrollBehavior = 'auto';
-            gridEl.scrollLeft = Math.round((total - 1) * step);
+            gridEl.scrollLeft = Math.round(lastIdx * step);
             void gridEl.offsetWidth;
             gridEl.style.scrollBehavior = 'smooth';
-            idx = total - 1;
+            idx = lastIdx;
             return;
           }
           idx = n;
@@ -313,7 +350,8 @@ function addCustomCarouselPanel(BlockEdit) {
           prevBtn: prevBtn,
           nextBtn: nextBtn,
           resizeObs: resizeObs,
-          scrollFn: scrollFn
+          scrollFn: scrollFn,
+          preventScroll: preventScroll
         };
       }
       if (frblGridOption !== 'none') {

--- a/assets/carousel/frontblocks-advanced-option.jsx
+++ b/assets/carousel/frontblocks-advanced-option.jsx
@@ -56,6 +56,9 @@ function findGridEl( blockEl, name ) {
 		// Walk up to 4 levels deep to find where the child blocks live.
 		return findSlidesParent( blockEl, 4 ) || blockEl;
 	}
+	if ( name === 'core/query' ) {
+		return blockEl.querySelector( '.wp-block-post-template' ) || null;
+	}
 	return null;
 }
 
@@ -64,7 +67,8 @@ function addCustomCarouselPanel( BlockEdit ) {
 		if (
 			props.name !== 'generateblocks/grid' &&
 			props.name !== 'generateblocks/element' &&
-			props.name !== 'core/group'
+			props.name !== 'core/group' &&
+			props.name !== 'core/query'
 		) {
 			return <BlockEdit { ...props } />;
 		}

--- a/assets/carousel/frontblocks-advanced-option.jsx
+++ b/assets/carousel/frontblocks-advanced-option.jsx
@@ -130,16 +130,23 @@ function addCustomCarouselPanel( BlockEdit ) {
 
 			// Restore gridEl styles.
 			try {
+				const { preventScroll } = stateRef.current;
+				if ( preventScroll ) {
+					gridEl.removeEventListener( 'wheel', preventScroll );
+					gridEl.removeEventListener( 'touchstart', preventScroll );
+					gridEl.removeEventListener( 'touchmove', preventScroll );
+				}
 				gridEl.classList.remove( 'frbl-carousel-noscrollbar' );
 				[
 					'display', 'flex-wrap', 'gap',
 					'overflow-x', 'scroll-behavior',
 					'padding-left', 'padding-right',
+					'max-width', 'grid-template-columns',
 				].forEach( ( p ) => gridEl.style.removeProperty( p ) );
 
 					slides.forEach( ( slide ) => {
 						[ 'flex-shrink', 'width', 'min-width',
-						  'margin-left', 'margin-right', 'grid-column',
+						  'margin-left', 'margin-right', 'grid-column', 'grid-row',
 						].forEach( ( p ) => slide.style.removeProperty( p ) );
 					} );
 				} catch ( e ) {}
@@ -166,16 +173,28 @@ function addCustomCarouselPanel( BlockEdit ) {
 				const gridEl = findGridEl( blockEl, props.name );
 				if ( ! gridEl ) return;
 
-				// Slides = direct children that are real blocks (UUID data-block).
-				const slides = Array.from( gridEl.children ).filter(
-					( el ) => UUID_RE.test( el.dataset.block || '' )
-				);
+				// For core/query, <li> items don't have data-block UUIDs (server-rendered).
+				// For other blocks, filter by UUID data-block attribute.
+				const isQueryLoop = props.name === 'core/query';
+				const slides = isQueryLoop
+					? Array.from( gridEl.children ).filter( ( el ) => el.tagName === 'LI' )
+					: Array.from( gridEl.children ).filter( ( el ) => UUID_RE.test( el.dataset.block || '' ) );
 				if ( slides.length === 0 ) return;
 
 				const perView    = Math.max( 1, parseInt( frblItemsToView ) || 4 );
 				const gap        = Math.max( 0, parseInt( frblGap ) || 20 );
 				const btnColor   = frblButtonColor   || '#fff';
 				const btnBg      = frblButtonBgColor || 'rgba(0,0,0,0.45)';
+
+				// For core/query, force flex via setProperty to beat WP's grid CSS.
+				if ( isQueryLoop ) {
+					gridEl.style.setProperty( 'display', 'flex', 'important' );
+					gridEl.style.setProperty( 'flex-wrap', 'nowrap', 'important' );
+					gridEl.style.setProperty( 'max-width', 'none', 'important' );
+					gridEl.style.setProperty( 'grid-template-columns', 'none', 'important' );
+					gridEl.style.setProperty( 'list-style', 'none', 'important' );
+					gridEl.style.setProperty( 'padding-left', '0', 'important' );
+				}
 
 				// Measure content-box width before any style changes.
 				const editorWin  = editorDoc.defaultView || window;
@@ -193,15 +212,17 @@ function addCustomCarouselPanel( BlockEdit ) {
 			// ── Apply scroll-based layout directly to gridEl ─────────────
 			// No DOM restructuring → no React reconciliation conflicts.
 			gridEl.classList.add( 'frbl-carousel-noscrollbar' );
-			gridEl.style.display        = 'flex';
-			gridEl.style.flexWrap       = 'nowrap';
+			if ( ! isQueryLoop ) {
+				gridEl.style.display        = 'flex';
+				gridEl.style.flexWrap       = 'nowrap';
+				gridEl.style.paddingLeft    = ARROW_W + 'px';
+			} else {
+				// paddingLeft already set via setProperty above; override with arrow offset.
+				gridEl.style.setProperty( 'padding-left', ARROW_W + 'px', 'important' );
+			}
 			gridEl.style.gap            = gap + 'px';
 			gridEl.style.overflowX      = 'scroll';
 			gridEl.style.scrollBehavior = 'smooth';
-			// paddingLeft creates left space for the prev arrow.
-			// paddingRight is NOT used because Chrome ignores it in scroll extent;
-			// a spacer flex child is appended instead to guarantee right-side space.
-			gridEl.style.paddingLeft    = ARROW_W + 'px';
 			gridEl.style.paddingRight   = '0';
 
 			slides.forEach( ( slide ) => {
@@ -211,6 +232,7 @@ function addCustomCarouselPanel( BlockEdit ) {
 				slide.style.marginLeft  = '0';
 				slide.style.marginRight = '0';
 				slide.style.gridColumn  = 'unset';
+				slide.style.gridRow     = 'unset';
 			} );
 
 			// Right-side spacer: Chrome does not include padding-right in horizontal
@@ -221,13 +243,19 @@ function addCustomCarouselPanel( BlockEdit ) {
 			spacer.style.cssText = `display:block;flex-shrink:0;width:${ ARROW_W }px;min-width:${ ARROW_W }px;`;
 			gridEl.insertBefore( spacer, appender || null );
 
-			// ── Navigation (scrollLeft, infinite loop) ───────────────────
+			// Prevent manual scroll — only arrows drive navigation.
+			const preventScroll = ( e ) => e.preventDefault();
+			gridEl.addEventListener( 'wheel', preventScroll, { passive: false } );
+			gridEl.addEventListener( 'touchstart', preventScroll, { passive: false } );
+			gridEl.addEventListener( 'touchmove', preventScroll, { passive: false } );
+
+			// ── Navigation (scrollLeft, item-by-item) ────────────────────
 				let idx = 0;
+				const lastIdx = Math.max( 0, slides.length - perView );
 
 				function scrollTo( n ) {
-					const total = slides.length;
-					if ( n >= total ) {
-						// Forward past last: instant snap to 0 then continue.
+					if ( n > lastIdx ) {
+						// Wrap forward to start.
 						gridEl.style.scrollBehavior = 'auto';
 						gridEl.scrollLeft = 0;
 						void gridEl.offsetWidth;
@@ -236,12 +264,12 @@ function addCustomCarouselPanel( BlockEdit ) {
 						return;
 					}
 					if ( n < 0 ) {
-						// Back past first: instant snap to last.
+						// Wrap back to end.
 						gridEl.style.scrollBehavior = 'auto';
-						gridEl.scrollLeft = Math.round( ( total - 1 ) * step );
+						gridEl.scrollLeft = Math.round( lastIdx * step );
 						void gridEl.offsetWidth;
 						gridEl.style.scrollBehavior = 'smooth';
-						idx = total - 1;
+						idx = lastIdx;
 						return;
 					}
 					idx = n;
@@ -292,7 +320,7 @@ function addCustomCarouselPanel( BlockEdit ) {
 				const scrollFn       = updateArrowPos;
 				editorScrollEl.addEventListener( 'scroll', scrollFn, { passive: true, capture: true } );
 
-				stateRef.current = { gridEl, slides, spacer, prevBtn, nextBtn, resizeObs, scrollFn };
+				stateRef.current = { gridEl, slides, spacer, prevBtn, nextBtn, resizeObs, scrollFn, preventScroll };
 			}
 
 			if ( frblGridOption !== 'none' ) {

--- a/assets/carousel/frontblocks-carousel.css
+++ b/assets/carousel/frontblocks-carousel.css
@@ -270,3 +270,17 @@
   column-gap: 0 !important;
   gap: 0 !important;
 }
+
+/* core/query (wp-block-post-template) as carousel container */
+ul.frontblocks-carousel.wp-block-post-template,
+ul.frontblocks-carousel.wp-block-post-template.glide__slides {
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0;
+  display: flex;
+}
+
+ul.frontblocks-carousel.wp-block-post-template > li.glide__slide {
+  display: block;
+  height: auto;
+}

--- a/assets/carousel/frontblocks-carousel.css
+++ b/assets/carousel/frontblocks-carousel.css
@@ -271,16 +271,28 @@
   gap: 0 !important;
 }
 
-/* core/query (wp-block-post-template) as carousel container */
-ul.frontblocks-carousel.wp-block-post-template,
-ul.frontblocks-carousel.wp-block-post-template.glide__slides {
+/* core/query (wp-block-post-template) as carousel — override WP grid layout */
+.frontblocks ul.glide__slides.wp-block-post-template,
+.frontblocks ul.glide__slides.wp-block-post-template.is-layout-grid,
+.frontblocks ul.glide__slides.wp-block-post-template.is-layout-flex,
+.frontblocks ul.glide__slides.wp-block-post-template.is-layout-flow {
+  display: flex;
+  flex-wrap: nowrap;
+  grid-template-columns: unset;
+  grid-auto-rows: unset;
+  max-width: none;
   list-style: none;
   padding-left: 0;
   margin-left: 0;
-  display: flex;
+  margin-right: 0;
 }
 
-ul.frontblocks-carousel.wp-block-post-template > li.glide__slide {
+.frontblocks ul.glide__slides.wp-block-post-template > li.glide__slide,
+.frontblocks ul.glide__slides.wp-block-post-template > li.glide__slide.wp-block-post {
   display: block;
   height: auto;
+  grid-column: unset;
+  grid-row: unset;
+  float: none;
+  clear: none;
 }

--- a/assets/carousel/frontblocks-carousel.js
+++ b/assets/carousel/frontblocks-carousel.js
@@ -48,6 +48,16 @@ window.addEventListener('load', function (event) {
 
             // Add classes
             item.classList.add('glide__slides', 'glide-' + Math.floor(Math.random() * 1000));
+            // Force flex layout via inline style to beat WP grid CSS (columns-N, is-layout-grid).
+            if (item.classList.contains('wp-block-post-template')) {
+                item.style.setProperty('display', 'flex', 'important');
+                item.style.setProperty('flex-wrap', 'nowrap', 'important');
+                item.style.setProperty('max-width', 'none', 'important');
+                item.style.setProperty('grid-template-columns', 'none', 'important');
+                item.style.setProperty('list-style', 'none', 'important');
+                item.style.setProperty('padding-left', '0', 'important');
+                item.style.setProperty('margin-left', '0', 'important');
+            }
             for (const child of item.children) {
                 child.classList.add('glide__slide');
             }

--- a/includes/Frontend/Carousel.php
+++ b/includes/Frontend/Carousel.php
@@ -38,6 +38,7 @@ class Carousel {
 		add_filter( 'render_block_generateblocks/grid', array( $this, 'add_custom_attributes_to_grid_block' ), 10, 2 );
 		add_filter( 'render_block_generateblocks/element', array( $this, 'add_custom_attributes_to_element_block' ), 10, 2 );
 		add_filter( 'render_block_core/group', array( $this, 'add_custom_attributes_to_core_group_block' ), 10, 2 );
+		add_filter( 'render_block_core/query', array( $this, 'add_custom_attributes_to_query_block' ), 10, 2 );
 		add_action( 'init', array( $this, 'register_custom_attributes' ), 5 );
 	}
 
@@ -298,6 +299,65 @@ class Carousel {
 	}
 
 	/**
+	 * Add custom attributes to core/query block.
+	 *
+	 * @param string $block_content Block content.
+	 * @param array  $block Block attributes.
+	 * @return string
+	 */
+	public function add_custom_attributes_to_query_block( $block_content, $block ) {
+		$attrs         = $block['attrs'] ?? array();
+		$custom_option = isset( $attrs['frblGridOption'] ) ? sanitize_text_field( $attrs['frblGridOption'] ) : '';
+
+		if ( 'carousel' !== $custom_option && 'slider' !== $custom_option ) {
+			return $block_content;
+		}
+
+		$items_to_view      = isset( $attrs['frblItemsToView'] ) ? (int) $attrs['frblItemsToView'] : 4;
+		$laptop_to_view     = isset( $attrs['frblLaptopToView'] ) ? (int) $attrs['frblLaptopToView'] : 3;
+		$tablet_to_view     = isset( $attrs['frblTabletToView'] ) ? (int) $attrs['frblTabletToView'] : 2;
+		$responsive_to_view = isset( $attrs['frblResponsiveToView'] ) ? (int) $attrs['frblResponsiveToView'] : 1;
+		$autoplay           = isset( $attrs['frblAutoplay'] ) ? ( (int) $attrs['frblAutoplay'] * 1000 ) : '';
+		$gap                = isset( $attrs['frblGap'] ) && '' !== $attrs['frblGap'] ? (int) $attrs['frblGap'] : 20;
+		$rewind             = isset( $attrs['frblRewind'] ) ? (bool) $attrs['frblRewind'] : true;
+		$buttons            = isset( $attrs['frblButtons'] ) ? sanitize_text_field( $attrs['frblButtons'] ) : 'arrows';
+		$button_color       = isset( $attrs['frblButtonColor'] ) ? sanitize_text_field( $attrs['frblButtonColor'] ) : '';
+		$button_bg_color    = isset( $attrs['frblButtonBgColor'] ) ? sanitize_text_field( $attrs['frblButtonBgColor'] ) : '';
+		$buttons_position   = isset( $attrs['frblButtonsPosition'] ) ? sanitize_text_field( $attrs['frblButtonsPosition'] ) : 'side';
+		$disable_on_desktop = isset( $attrs['frblDisableOnDesktop'] ) ? (bool) $attrs['frblDisableOnDesktop'] : false;
+
+		$extra = '';
+		if ( 'slider' === $custom_option ) {
+			$extra .= ' data-rewind="' . esc_attr( $rewind ) . '"';
+		}
+
+		$block_content = preg_replace(
+			'/<ul([^>]*)class="([^"]*wp-block-post-template[^"]*)"([^>]*)>/',
+			'<ul$1class="$2 frontblocks-carousel"$3' .
+				' data-type="' . esc_attr( $custom_option ) . '"' .
+				' data-view="' . esc_attr( $items_to_view ) . '"' .
+				' data-laptop-view="' . esc_attr( $laptop_to_view ) . '"' .
+				' data-tablet-view="' . esc_attr( $tablet_to_view ) . '"' .
+				' data-mobile-view="' . esc_attr( $responsive_to_view ) . '"' .
+				' data-autoplay="' . esc_attr( $autoplay ) . '"' .
+				' data-gap="' . esc_attr( $gap ) . '"' .
+				' data-buttons="' . esc_attr( $buttons ) . '"' .
+				' data-buttons-color="' . esc_attr( $button_color ) . '"' .
+				' data-buttons-background-color="' . esc_attr( $button_bg_color ) . '"' .
+				' data-buttons-position="' . esc_attr( $buttons_position ) . '"' .
+				' data-disable-on-desktop="' . esc_attr( $disable_on_desktop ? 'true' : 'false' ) . '"' .
+				$extra .
+				'>',
+			$block_content,
+			1
+		);
+
+		$this->enqueue_carousel_assets();
+
+		return $block_content;
+	}
+
+	/**
 	 * Register custom attributes for blocks.
 	 *
 	 * @return void
@@ -310,6 +370,9 @@ class Carousel {
 			9,
 			2
 		);
+
+		// Register attributes for core/query block.
+		add_filter( 'register_block_type_args', array( $this, 'register_query_block_attributes' ), 10, 2 );
 
 		// Register attributes from frontend side too.
 		add_action(
@@ -387,6 +450,39 @@ class Carousel {
 	}
 
 	/**
+	 * Register custom attributes for core/query block.
+	 *
+	 * @param array  $args       Block type arguments.
+	 * @param string $block_type Block type name.
+	 * @return array
+	 */
+	public function register_query_block_attributes( $args, $block_type ) {
+		if ( 'core/query' !== $block_type ) {
+			return $args;
+		}
+
+		if ( ! isset( $args['attributes'] ) ) {
+			$args['attributes'] = array();
+		}
+
+		$args['attributes']['frblGridOption']       = array( 'type' => 'string', 'default' => 'none' );
+		$args['attributes']['frblItemsToView']      = array( 'type' => 'string', 'default' => '4' );
+		$args['attributes']['frblLaptopToView']     = array( 'type' => 'string', 'default' => '3' );
+		$args['attributes']['frblTabletToView']     = array( 'type' => 'string', 'default' => '2' );
+		$args['attributes']['frblResponsiveToView'] = array( 'type' => 'string', 'default' => '1' );
+		$args['attributes']['frblAutoplay']         = array( 'type' => 'string', 'default' => '' );
+		$args['attributes']['frblGap']              = array( 'type' => 'string', 'default' => '20' );
+		$args['attributes']['frblRewind']           = array( 'type' => 'boolean', 'default' => true );
+		$args['attributes']['frblButtons']          = array( 'type' => 'string', 'default' => 'arrows' );
+		$args['attributes']['frblButtonColor']      = array( 'type' => 'string', 'default' => '' );
+		$args['attributes']['frblButtonBgColor']    = array( 'type' => 'string', 'default' => '' );
+		$args['attributes']['frblButtonsPosition']  = array( 'type' => 'string', 'default' => 'side' );
+		$args['attributes']['frblDisableOnDesktop'] = array( 'type' => 'boolean', 'default' => false );
+
+		return $args;
+	}
+
+	/**
 	 * Add inline script for block attributes.
 	 *
 	 * @return void
@@ -399,7 +495,7 @@ class Carousel {
 				'blocks.registerBlockType',
 				'frontblocks/grid-attributes',
 				function( settings, name ) {
-					if ( name !== 'generateblocks/grid' && name !== 'generateblocks/element' && name !== 'core/group' ) {
+					if ( name !== 'generateblocks/grid' && name !== 'generateblocks/element' && name !== 'core/group' && name !== 'core/query' ) {
 						return settings;
 					}
 

--- a/includes/Frontend/Carousel.php
+++ b/includes/Frontend/Carousel.php
@@ -465,19 +465,58 @@ class Carousel {
 			$args['attributes'] = array();
 		}
 
-		$args['attributes']['frblGridOption']       = array( 'type' => 'string', 'default' => 'none' );
-		$args['attributes']['frblItemsToView']      = array( 'type' => 'string', 'default' => '4' );
-		$args['attributes']['frblLaptopToView']     = array( 'type' => 'string', 'default' => '3' );
-		$args['attributes']['frblTabletToView']     = array( 'type' => 'string', 'default' => '2' );
-		$args['attributes']['frblResponsiveToView'] = array( 'type' => 'string', 'default' => '1' );
-		$args['attributes']['frblAutoplay']         = array( 'type' => 'string', 'default' => '' );
-		$args['attributes']['frblGap']              = array( 'type' => 'string', 'default' => '20' );
-		$args['attributes']['frblRewind']           = array( 'type' => 'boolean', 'default' => true );
-		$args['attributes']['frblButtons']          = array( 'type' => 'string', 'default' => 'arrows' );
-		$args['attributes']['frblButtonColor']      = array( 'type' => 'string', 'default' => '' );
-		$args['attributes']['frblButtonBgColor']    = array( 'type' => 'string', 'default' => '' );
-		$args['attributes']['frblButtonsPosition']  = array( 'type' => 'string', 'default' => 'side' );
-		$args['attributes']['frblDisableOnDesktop'] = array( 'type' => 'boolean', 'default' => false );
+		$args['attributes']['frblGridOption']       = array(
+			'type'    => 'string',
+			'default' => 'none',
+		);
+		$args['attributes']['frblItemsToView']      = array(
+			'type'    => 'string',
+			'default' => '4',
+		);
+		$args['attributes']['frblLaptopToView']     = array(
+			'type'    => 'string',
+			'default' => '3',
+		);
+		$args['attributes']['frblTabletToView']     = array(
+			'type'    => 'string',
+			'default' => '2',
+		);
+		$args['attributes']['frblResponsiveToView'] = array(
+			'type'    => 'string',
+			'default' => '1',
+		);
+		$args['attributes']['frblAutoplay']         = array(
+			'type'    => 'string',
+			'default' => '',
+		);
+		$args['attributes']['frblGap']              = array(
+			'type'    => 'string',
+			'default' => '20',
+		);
+		$args['attributes']['frblRewind']           = array(
+			'type'    => 'boolean',
+			'default' => true,
+		);
+		$args['attributes']['frblButtons']          = array(
+			'type'    => 'string',
+			'default' => 'arrows',
+		);
+		$args['attributes']['frblButtonColor']      = array(
+			'type'    => 'string',
+			'default' => '',
+		);
+		$args['attributes']['frblButtonBgColor']    = array(
+			'type'    => 'string',
+			'default' => '',
+		);
+		$args['attributes']['frblButtonsPosition']  = array(
+			'type'    => 'string',
+			'default' => 'side',
+		);
+		$args['attributes']['frblDisableOnDesktop'] = array(
+			'type'    => 'boolean',
+			'default' => false,
+		);
 
 		return $args;
 	}


### PR DESCRIPTION
## Summary

Added carousel/slider support for the native WordPress `core/query` (Query Loop) block.

- Registered custom carousel attributes (`frblGridOption`, `frblItemsToView`, `frblLaptopToView`, etc.) on the `core/query` block via `register_block_type_args` filter
- Added `add_custom_attributes_to_query_block()` method in `Carousel.php` that injects carousel data attributes on the `wp-block-post-template` `<ul>` element
- Handled the editor preview: `core/query` slides are `<li>` elements without `data-block` UUIDs (server-rendered), so child detection was updated accordingly
- Used `setProperty('important')` to override WordPress's native grid CSS on the post template in both the editor and frontend
- Added CSS rules scoped to `.frontblocks ul.glide__slides.wp-block-post-template` to reset grid layout and apply flex for the carousel
- Disabled manual scroll (wheel/touch) in the editor preview — navigation is arrow-only