### PR TITLE
add counter in native blocks

### DIFF
--- a/assets/counter/frontblocks-counter-option.jsx
+++ b/assets/counter/frontblocks-counter-option.jsx
@@ -1,138 +1,144 @@
 const { createHigherOrderComponent } = wp.compose;
 const { Fragment, useEffect } = wp.element;
-const { InspectorControls } = wp.blockEditor; 
+const { InspectorControls } = wp.blockEditor;
 const { PanelBody, ToggleControl, TextControl } = wp.components;
 const { select, dispatch } = wp.data;
 const { __ } = wp.i18n;
 
+const COUNTER_BLOCKS = [
+	'generateblocks/text',
+	'generateblocks/headline',
+	'core/heading',
+	'core/paragraph',
+];
+
 wp.hooks.addFilter(
-    'blocks.registerBlockType',
-    'frontblocks/add-counter-attribute',
-    ( settings, name ) => {
-        if ( name === 'generateblocks/text' || name === 'generateblocks/headline' ) {
-            settings.attributes = Object.assign( settings.attributes, {
-                isCounterActive: {
-                    type: 'boolean',
-                    default: false,
-                },
-                animationDuration: { 
-                    type: 'number',
-                    default: 2000,
-                },
-                finalNumber: {
-                    type: 'string',
-                    default: '',
-                },
-                numberPrefix: {
-                    type: 'string',
-                    default: '',
-                },
-                numberSuffix: {
-                    type: 'string',
-                    default: '',
-                },
-            } );
-        }
-        return settings;
-    }
+	'blocks.registerBlockType',
+	'frontblocks/add-counter-attribute',
+	( settings, name ) => {
+		if ( ! COUNTER_BLOCKS.includes( name ) ) {
+			return settings;
+		}
+		settings.attributes = Object.assign( settings.attributes, {
+			isCounterActive: {
+				type: 'boolean',
+				default: false,
+			},
+			animationDuration: {
+				type: 'number',
+				default: 2000,
+			},
+			finalNumber: {
+				type: 'string',
+				default: '',
+			},
+			numberPrefix: {
+				type: 'string',
+				default: '',
+			},
+			numberSuffix: {
+				type: 'string',
+				default: '',
+			},
+		} );
+		return settings;
+	}
 );
 
-const withHeadlineCounterControl = createHigherOrderComponent( ( BlockEdit ) => {
-    return ( props ) => {
-        if ( props.name !== BLOCK_NAME ) {
-            return <BlockEdit { ...props } />;
-        }
+const withCounterControl = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		if ( ! COUNTER_BLOCKS.includes( props.name ) ) {
+			return <BlockEdit { ...props } />;
+		}
 
-        const { attributes, setAttributes, clientId } = props;
-        const { isCounterActive, animationDuration, finalNumber, numberPrefix, numberSuffix } = attributes;
-        
-        const durationInSeconds = animationDuration / 1000;
+		const { attributes, setAttributes, clientId } = props;
+		const { isCounterActive, animationDuration, finalNumber, numberPrefix, numberSuffix } = attributes;
 
-        useEffect(() => {
-            if (isCounterActive) {
-                const block = select('core/block-editor').getBlock(clientId);
-                if (!block) return;
+		const durationInSeconds = animationDuration / 1000;
 
-                const formattedNumber = `${numberPrefix}${finalNumber}${numberSuffix}`;
-                
-                if (finalNumber && block.attributes.content !== formattedNumber) {
-                    dispatch('core/block-editor').updateBlockAttributes(clientId, {
-                        content: formattedNumber
-                    });
-                }
-            }
-        }, [isCounterActive, finalNumber, numberPrefix, numberSuffix, clientId]);
+		useEffect( () => {
+			if ( isCounterActive && finalNumber ) {
+				const block = select( 'core/block-editor' ).getBlock( clientId );
+				if ( ! block ) return;
 
-        return (
-            <Fragment>
-                <BlockEdit { ...props } />
+				const formattedNumber = `${ numberPrefix }${ finalNumber }${ numberSuffix }`;
 
-                <InspectorControls>
-                    <PanelBody 
-                        title={ __( 'FrontBlocks - Counter Effect', 'frontblocks' ) }
-                        initialOpen={ false }
-                    >
-                        <ToggleControl
-                            label={ __( 'Activate Counter Effect', 'frontblocks' ) }
-                            help={ isCounterActive ? 
-                                __( 'The number in the headline will animate on scroll.', 'frontblocks' ) : 
-                                __( 'Enable to activate counting animation.', 'frontblocks' )
-                            }
-                            checked={ isCounterActive }
-                            onChange={ ( val ) => setAttributes( { isCounterActive: val } ) }
-                        />
+				if ( block.attributes.content !== formattedNumber ) {
+					dispatch( 'core/block-editor' ).updateBlockAttributes( clientId, {
+						content: formattedNumber,
+					} );
+				}
+			}
+		}, [ isCounterActive, finalNumber, numberPrefix, numberSuffix, clientId ] );
 
-                        {isCounterActive && (
-                            <>
-                                <TextControl
-                                    label={ __( 'Final Number', 'frontblocks' ) }
-                                    value={ finalNumber }
-                                    onChange={ (val) => setAttributes({ finalNumber: val }) }
-                                    help={ __( 'The number to count up to (e.g.: 100).', 'frontblocks' ) }
-                                />
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<InspectorControls>
+					<PanelBody
+						title={ __( 'FrontBlocks - Counter Effect', 'frontblocks' ) }
+						initialOpen={ false }
+					>
+						<ToggleControl
+							label={ __( 'Activate Counter Effect', 'frontblocks' ) }
+							help={ isCounterActive ?
+								__( 'The number will animate on scroll.', 'frontblocks' ) :
+								__( 'Enable to activate counting animation.', 'frontblocks' )
+							}
+							checked={ isCounterActive }
+							onChange={ ( val ) => setAttributes( { isCounterActive: val } ) }
+						/>
 
-                                <TextControl
-                                    label={ __( 'Number Prefix', 'frontblocks' ) }
-                                    value={ numberPrefix }
-                                    onChange={ (val) => setAttributes({ numberPrefix: val }) }
-                                    help={ __( 'Text to display before the number (e.g.: $, €).', 'frontblocks' ) }
-                                />
+						{ isCounterActive && (
+							<>
+								<TextControl
+									label={ __( 'Final Number', 'frontblocks' ) }
+									value={ finalNumber }
+									onChange={ ( val ) => setAttributes( { finalNumber: val } ) }
+									help={ __( 'Number to count up to (e.g.: 100).', 'frontblocks' ) }
+								/>
 
-                                <TextControl
-                                    label={ __( 'Number Suffix', 'frontblocks' ) }
-                                    value={ numberSuffix }
-                                    onChange={ (val) => setAttributes({ numberSuffix: val }) }
-                                    help={ __( 'Text to display after the number (e.g.: %, +).', 'frontblocks' ) }
-                                />
+								<TextControl
+									label={ __( 'Number Prefix', 'frontblocks' ) }
+									value={ numberPrefix }
+									onChange={ ( val ) => setAttributes( { numberPrefix: val } ) }
+									help={ __( 'Text before the number (e.g.: $, €).', 'frontblocks' ) }
+								/>
 
-                                <TextControl
-                                    label={ __( 'Animation Duration (seconds)', 'frontblocks' ) }
-                                    value={ durationInSeconds }
-                                    onChange={ (val) => {
-                                        const seconds = parseFloat(val);
-                                        const milliseconds = isNaN(seconds) ? 0 : seconds * 1000;
-                                        setAttributes({ animationDuration: milliseconds });
-                                    } }
-                                    type="number"
-                                    step="0.1"
-                                    help={ __( 'Time in seconds for the animation.', 'frontblocks' ) }
-                                />
-                            </>
-                        )}
+								<TextControl
+									label={ __( 'Number Suffix', 'frontblocks' ) }
+									value={ numberSuffix }
+									onChange={ ( val ) => setAttributes( { numberSuffix: val } ) }
+									help={ __( 'Text after the number (e.g.: %, +).', 'frontblocks' ) }
+								/>
 
-                        <p style={ { marginTop: '10px', fontSize: '12px', color: '#777' } }>
-                            <small>{ __( "Make sure the text begins with a number (e.g., '123', '+500', or '€100').", 'frontblocks' ) }</small>
-                        </p>
-                    </PanelBody>
-                </InspectorControls>
-            </Fragment>
-        );
-    };
-}, 'withHeadlineCounterControl' );
+								<TextControl
+									label={ __( 'Animation Duration (seconds)', 'frontblocks' ) }
+									value={ durationInSeconds }
+									onChange={ ( val ) => {
+										const seconds      = parseFloat( val );
+										const milliseconds = isNaN( seconds ) ? 0 : seconds * 1000;
+										setAttributes( { animationDuration: milliseconds } );
+									} }
+									type="number"
+									step="0.1"
+									help={ __( 'Duration of the animation.', 'frontblocks' ) }
+								/>
+							</>
+						) }
+
+						<p style={ { marginTop: '10px', fontSize: '12px', color: '#777' } }>
+							<small>{ __( "Text must begin with a number (e.g., '123', '+500', '€100').", 'frontblocks' ) }</small>
+						</p>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	};
+}, 'withCounterControl' );
 
 wp.hooks.addFilter(
-    'editor.BlockEdit',
-    'frontblocks/headline-counter-control',
-
-    withHeadlineCounterControl
+	'editor.BlockEdit',
+	'frontblocks/counter-control',
+	withCounterControl
 );

--- a/assets/counter/frontblocks-counter.js
+++ b/assets/counter/frontblocks-counter.js
@@ -13,40 +13,38 @@ var _wp$data = wp.data,
   select = _wp$data.select,
   dispatch = _wp$data.dispatch;
 var __ = wp.i18n.__;
+var COUNTER_BLOCKS = ['generateblocks/text', 'generateblocks/headline', 'core/heading', 'core/paragraph'];
 wp.hooks.addFilter('blocks.registerBlockType', 'frontblocks/add-counter-attribute', function (settings, name) {
-  if (name === 'generateblocks/text' || name === 'generateblocks/headline') {
-    settings.attributes = Object.assign(settings.attributes, {
-      isCounterActive: {
-        type: 'boolean',
-        default: false
-      },
-      animationDuration: {
-        type: 'number',
-        default: 2000
-      },
-      startNumber: {
-        type: 'string',
-        default: '0'
-      },
-      finalNumber: {
-        type: 'string',
-        default: ''
-      },
-      numberPrefix: {
-        type: 'string',
-        default: ''
-      },
-      numberSuffix: {
-        type: 'string',
-        default: ''
-      }
-    });
+  if (!COUNTER_BLOCKS.includes(name)) {
+    return settings;
   }
+  settings.attributes = Object.assign(settings.attributes, {
+    isCounterActive: {
+      type: 'boolean',
+      default: false
+    },
+    animationDuration: {
+      type: 'number',
+      default: 2000
+    },
+    finalNumber: {
+      type: 'string',
+      default: ''
+    },
+    numberPrefix: {
+      type: 'string',
+      default: ''
+    },
+    numberSuffix: {
+      type: 'string',
+      default: ''
+    }
+  });
   return settings;
 });
-var withHeadlineCounterControl = createHigherOrderComponent(function (BlockEdit) {
+var withCounterControl = createHigherOrderComponent(function (BlockEdit) {
   return function (props) {
-    if (props.name !== BLOCK_NAME) {
+    if (!COUNTER_BLOCKS.includes(props.name)) {
       return /*#__PURE__*/React.createElement(BlockEdit, props);
     }
     var attributes = props.attributes,
@@ -54,29 +52,28 @@ var withHeadlineCounterControl = createHigherOrderComponent(function (BlockEdit)
       clientId = props.clientId;
     var isCounterActive = attributes.isCounterActive,
       animationDuration = attributes.animationDuration,
-      startNumber = attributes.startNumber,
       finalNumber = attributes.finalNumber,
       numberPrefix = attributes.numberPrefix,
       numberSuffix = attributes.numberSuffix;
     var durationInSeconds = animationDuration / 1000;
     useEffect(function () {
-      if (isCounterActive) {
+      if (isCounterActive && finalNumber) {
         var block = select('core/block-editor').getBlock(clientId);
         if (!block) return;
         var formattedNumber = "".concat(numberPrefix).concat(finalNumber).concat(numberSuffix);
-        if (finalNumber && block.attributes.content !== formattedNumber) {
+        if (block.attributes.content !== formattedNumber) {
           dispatch('core/block-editor').updateBlockAttributes(clientId, {
             content: formattedNumber
           });
         }
       }
-    }, [isCounterActive, startNumber, finalNumber, numberPrefix, numberSuffix, clientId]);
+    }, [isCounterActive, finalNumber, numberPrefix, numberSuffix, clientId]);
     return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(BlockEdit, props), /*#__PURE__*/React.createElement(InspectorControls, null, /*#__PURE__*/React.createElement(PanelBody, {
       title: __('FrontBlocks - Counter Effect', 'frontblocks'),
       initialOpen: false
     }, /*#__PURE__*/React.createElement(ToggleControl, {
       label: __('Activate Counter Effect', 'frontblocks'),
-      help: isCounterActive ? __('The number in the headline will animate on scroll.', 'frontblocks') : __('Enable to activate counting animation.', 'frontblocks'),
+      help: isCounterActive ? __('The number will animate on scroll.', 'frontblocks') : __('Enable to activate counting animation.', 'frontblocks'),
       checked: isCounterActive,
       onChange: function onChange(val) {
         return setAttributes({
@@ -84,15 +81,6 @@ var withHeadlineCounterControl = createHigherOrderComponent(function (BlockEdit)
         });
       }
     }), isCounterActive && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(TextControl, {
-      label: __('Start Number', 'frontblocks'),
-      value: startNumber,
-      onChange: function onChange(val) {
-        return setAttributes({
-          startNumber: val
-        });
-      },
-      help: __('The number to start counting from (e.g.: 0).', 'frontblocks')
-    }), /*#__PURE__*/React.createElement(TextControl, {
       label: __('Final Number', 'frontblocks'),
       value: finalNumber,
       onChange: function onChange(val) {
@@ -100,7 +88,7 @@ var withHeadlineCounterControl = createHigherOrderComponent(function (BlockEdit)
           finalNumber: val
         });
       },
-      help: __('The number to count up to (e.g.: 100).', 'frontblocks')
+      help: __('Number to count up to (e.g.: 100).', 'frontblocks')
     }), /*#__PURE__*/React.createElement(TextControl, {
       label: __('Number Prefix', 'frontblocks'),
       value: numberPrefix,
@@ -109,7 +97,7 @@ var withHeadlineCounterControl = createHigherOrderComponent(function (BlockEdit)
           numberPrefix: val
         });
       },
-      help: __('Text to display before the number (e.g.: $, €).', 'frontblocks')
+      help: __('Text before the number (e.g.: $, €).', 'frontblocks')
     }), /*#__PURE__*/React.createElement(TextControl, {
       label: __('Number Suffix', 'frontblocks'),
       value: numberSuffix,
@@ -118,7 +106,7 @@ var withHeadlineCounterControl = createHigherOrderComponent(function (BlockEdit)
           numberSuffix: val
         });
       },
-      help: __('Text to display after the number (e.g.: %, +).', 'frontblocks')
+      help: __('Text after the number (e.g.: %, +).', 'frontblocks')
     }), /*#__PURE__*/React.createElement(TextControl, {
       label: __('Animation Duration (seconds)', 'frontblocks'),
       value: durationInSeconds,
@@ -131,14 +119,14 @@ var withHeadlineCounterControl = createHigherOrderComponent(function (BlockEdit)
       },
       type: "number",
       step: "0.1",
-      help: __('Time in seconds for the animation.', 'frontblocks')
+      help: __('Duration of the animation.', 'frontblocks')
     })), /*#__PURE__*/React.createElement("p", {
       style: {
         marginTop: '10px',
         fontSize: '12px',
         color: '#777'
       }
-    }, /*#__PURE__*/React.createElement("small", null, __("Make sure the text begins with a number (e.g., '123', '+500', or '€100').", 'frontblocks'))))));
+    }, /*#__PURE__*/React.createElement("small", null, __("Text must begin with a number (e.g., '123', '+500', '€100').", 'frontblocks'))))));
   };
-}, 'withHeadlineCounterControl');
-wp.hooks.addFilter('editor.BlockEdit', 'frontblocks/headline-counter-control', withHeadlineCounterControl);
+}, 'withCounterControl');
+wp.hooks.addFilter('editor.BlockEdit', 'frontblocks/counter-control', withCounterControl);

--- a/includes/Frontend/Counter.php
+++ b/includes/Frontend/Counter.php
@@ -82,7 +82,8 @@ class Counter {
 	 * @return string Modified block content with counter functionality.
 	 */
 	public function render_block_counter( $block_content, $block ) {
-		if ( 'generateblocks/text' !== $block['blockName'] ) {
+		$supported = array( 'generateblocks/text', 'generateblocks/headline', 'core/heading', 'core/paragraph' );
+		if ( ! in_array( $block['blockName'], $supported, true ) ) {
 			return $block_content;
 		}
 


### PR DESCRIPTION
## Summary

Extended the counter animation feature to support native WordPress blocks in addition to GenerateBlocks.

- Added `core/heading` and `core/paragraph` to the list of supported blocks (previously only `generateblocks/text` and `generateblocks/headline`)
- Refactored block detection to use a `COUNTER_BLOCKS` array instead of individual `if` conditions
- Removed the unused `startNumber` attribute
- Renamed internal HOC from `withHeadlineCounterControl` to `withCounterControl` and updated filter namespace accordingly
- Fixed a conditional bug: counter update now only fires when both `isCounterActive` and `finalNumber` are truthy