### PR TITLE
Fix category product

### DIFF
--- a/assets/product-categories/frontblocks-product-categories-option.jsx
+++ b/assets/product-categories/frontblocks-product-categories-option.jsx
@@ -205,12 +205,12 @@ function ProductCategoriesEdit(props) {
                   label={__('Image Size', 'frontblocks')}
                   value={imageSize}
                   options={[
-                     { label: __('Miniatura WooCommerce', 'frontblocks'), value: 'woocommerce_thumbnail' },
-                     { label: __('Imagen de producto (WooCommerce)', 'frontblocks'), value: 'woocommerce_single' },
-                     { label: __('Tamaño completo', 'frontblocks'), value: 'full' },
+                     { label: __('WooCommerce Thumbnail', 'frontblocks'), value: 'woocommerce_thumbnail' },
+                     { label: __('Product Image (WooCommerce)', 'frontblocks'), value: 'woocommerce_single' },
+                     { label: __('Full size', 'frontblocks'), value: 'full' },
                   ]}
                   onChange={(val) => setAttributes({ imageSize: val })}
-                  help={__('Tamaño de imagen de cada categoría.', 'frontblocks')}
+                  help={__('Image size for each category.', 'frontblocks')}
                />
 
             </PanelBody>

--- a/assets/product-categories/frontblocks-product-categories-option.jsx
+++ b/assets/product-categories/frontblocks-product-categories-option.jsx
@@ -200,21 +200,6 @@ function ProductCategoriesEdit(props) {
                   help={__('Display the number of products in each category.', 'frontblocks')}
                />
 
-               <ToggleControl
-                  label={__('Show Button', 'frontblocks')}
-                  checked={showButton}
-                  onChange={(val) => setAttributes({ showButton: val })}
-                  help={__('Display a button at the bottom of each category card.', 'frontblocks')}
-               />
-
-               { showButton && (
-                  <TextControl
-                     label={__('Button Text', 'frontblocks')}
-                     value={buttonText}
-                     onChange={(val) => setAttributes({ buttonText: val })}
-                     placeholder={__('Shop now', 'frontblocks')}
-                  />
-               ) }
             </PanelBody>
 
             <PanelBody
@@ -293,8 +278,22 @@ function ProductCategoriesEdit(props) {
                </TabPanel>
             </PanelBody>
 
-            { showButton && (
-               <PanelBody title={ __( 'Button Style', 'frontblocks' ) } initialOpen={ false }>
+            <PanelBody title={ __( 'Button Style', 'frontblocks' ) } initialOpen={ false }>
+               <ToggleControl
+                  label={ __( 'Show Button', 'frontblocks' ) }
+                  checked={ showButton }
+                  onChange={ (val) => setAttributes({ showButton: val }) }
+                  help={ __( 'Display a button at the bottom of each category card.', 'frontblocks' ) }
+               />
+
+               { showButton && (
+               <Fragment>
+               <TextControl
+                  label={ __( 'Button Text', 'frontblocks' ) }
+                  value={ buttonText }
+                  onChange={ (val) => setAttributes({ buttonText: val }) }
+                  placeholder={ __( 'Shop now', 'frontblocks' ) }
+               />
                   <RangeControl
                      label={ __( 'Font Size (px)', 'frontblocks' ) }
                      value={ btnFontSize }
@@ -380,8 +379,9 @@ function ProductCategoriesEdit(props) {
                         }
                      } }
                   </TabPanel>
-               </PanelBody>
-            ) }
+               </Fragment>
+               ) }
+            </PanelBody>
          </InspectorControls>
 
          <div {...blockProps}>

--- a/assets/product-categories/frontblocks-product-categories-option.jsx
+++ b/assets/product-categories/frontblocks-product-categories-option.jsx
@@ -1,17 +1,48 @@
 const { registerBlockType } = wp.blocks;
 const { Fragment, useState, useEffect } = wp.element;
 const { InspectorControls, useBlockProps } = wp.blockEditor;
-const { 
-   PanelBody, 
-   RangeControl, 
-   SelectControl, 
+const {
+   PanelBody,
+   RangeControl,
+   SelectControl,
    ToggleControl,
-   ColorPicker, 
+   ColorPicker,
+   ColorIndicator,
+   Dropdown,
+   Button,
    TabPanel,
    Spinner,
 } = wp.components;
 const { __ } = wp.i18n;
 const apiFetch = wp.apiFetch;
+
+function CompactColorPicker( { label, color, onChangeComplete, enableAlpha } ) {
+   return (
+      <div style={ { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '12px' } }>
+         <span style={ { fontSize: '12px' } }>{ label }</span>
+         <Dropdown
+            renderToggle={ ( { isOpen, onToggle } ) => (
+               <Button
+                  onClick={ onToggle }
+                  aria-expanded={ isOpen }
+                  style={ { padding: 0, minWidth: 0, background: 'none', border: 'none', boxShadow: 'none' } }
+               >
+                  <ColorIndicator colorValue={ color || 'transparent' } />
+               </Button>
+            ) }
+            renderContent={ () => (
+               <div style={ { padding: '8px' } }>
+                  <ColorPicker
+                     color={ color }
+                     onChangeComplete={ onChangeComplete }
+                     disableAlpha={ ! enableAlpha }
+                  />
+               </div>
+            ) }
+         />
+      </div>
+   );
+}
 
 function ProductCategoriesEdit(props) {
    const { attributes, setAttributes } = props;
@@ -47,8 +78,6 @@ function ProductCategoriesEdit(props) {
    const countLabel = count === 999 ? 
       __('Number of Categories (All)', 'frontblocks') : 
       __('Number of Categories', 'frontblocks');
-
-   const colorPickerCompactStyle = { maxWidth: '250px' };
 
    // Load categories from API.
    useEffect(() => {
@@ -178,60 +207,44 @@ function ProductCategoriesEdit(props) {
                      if (tab.name === 'normal') {
                         return (
                            <Fragment>
-                              <h4 style={{marginTop: '15px'}}>{__('Background Color', 'frontblocks')}</h4>
-                              <div style={colorPickerCompactStyle}>
-                                 <ColorPicker
-                                    color={bgColor}
-                                    onChangeComplete={(value) => setAttributes({ bgColor: value.rgb ? `rgba(${value.rgb.r}, ${value.rgb.g}, ${value.rgb.b}, ${value.rgb.a})` : value.hex })}
-                                    disableAlpha={false}
-                                 />
-                              </div>
-
-                              <h4 style={{marginTop: '15px'}}>{__('Border Color', 'frontblocks')}</h4>
-                              <div style={colorPickerCompactStyle}>
-                                 <ColorPicker
-                                    color={borderColor}
-                                    onChangeComplete={(value) => setAttributes({ borderColor: value.hex })}
-                                 />
-                              </div>
-
-                              <h4 style={{marginTop: '15px'}}>{__('Text Color', 'frontblocks')}</h4>
-                              <div style={colorPickerCompactStyle}>
-                                 <ColorPicker
-                                    color={textColor}
-                                    onChangeComplete={(value) => setAttributes({ textColor: value.hex })}
-                                 />
-                              </div>
+                              <CompactColorPicker
+                                 label={ __( 'Background Color', 'frontblocks' ) }
+                                 color={ bgColor }
+                                 enableAlpha={ true }
+                                 onChangeComplete={ (value) => setAttributes({ bgColor: value.rgb ? `rgba(${value.rgb.r}, ${value.rgb.g}, ${value.rgb.b}, ${value.rgb.a})` : value.hex }) }
+                              />
+                              <CompactColorPicker
+                                 label={ __( 'Border Color', 'frontblocks' ) }
+                                 color={ borderColor }
+                                 onChangeComplete={ (value) => setAttributes({ borderColor: value.hex }) }
+                              />
+                              <CompactColorPicker
+                                 label={ __( 'Text Color', 'frontblocks' ) }
+                                 color={ textColor }
+                                 onChangeComplete={ (value) => setAttributes({ textColor: value.hex }) }
+                              />
                            </Fragment>
                         );
                      }
                      if (tab.name === 'hover') {
                         return (
                            <Fragment>
-                              <h4 style={{marginTop: '15px'}}>{__('Hover Background Color', 'frontblocks')}</h4>
-                              <div style={colorPickerCompactStyle}>
-                                 <ColorPicker
-                                    color={hoverBgColor}
-                                    onChangeComplete={(value) => setAttributes({ hoverBgColor: value.rgb ? `rgba(${value.rgb.r}, ${value.rgb.g}, ${value.rgb.b}, ${value.rgb.a})` : value.hex })}
-                                    disableAlpha={false}
-                                 />
-                              </div>
-
-                              <h4 style={{marginTop: '15px'}}>{__('Hover Border Color', 'frontblocks')}</h4>
-                              <div style={colorPickerCompactStyle}>
-                                 <ColorPicker
-                                    color={hoverBorderColor}
-                                    onChangeComplete={(value) => setAttributes({ hoverBorderColor: value.hex })}
-                                 />
-                              </div>
-
-                              <h4 style={{marginTop: '15px'}}>{__('Hover Text Color', 'frontblocks')}</h4>
-                              <div style={colorPickerCompactStyle}>
-                                 <ColorPicker
-                                    color={hoverTextColor}
-                                    onChangeComplete={(value) => setAttributes({ hoverTextColor: value.hex })}
-                                 />
-                              </div>
+                              <CompactColorPicker
+                                 label={ __( 'Hover Background Color', 'frontblocks' ) }
+                                 color={ hoverBgColor }
+                                 enableAlpha={ true }
+                                 onChangeComplete={ (value) => setAttributes({ hoverBgColor: value.rgb ? `rgba(${value.rgb.r}, ${value.rgb.g}, ${value.rgb.b}, ${value.rgb.a})` : value.hex }) }
+                              />
+                              <CompactColorPicker
+                                 label={ __( 'Hover Border Color', 'frontblocks' ) }
+                                 color={ hoverBorderColor }
+                                 onChangeComplete={ (value) => setAttributes({ hoverBorderColor: value.hex }) }
+                              />
+                              <CompactColorPicker
+                                 label={ __( 'Hover Text Color', 'frontblocks' ) }
+                                 color={ hoverTextColor }
+                                 onChangeComplete={ (value) => setAttributes({ hoverTextColor: value.hex }) }
+                              />
                            </Fragment>
                         );
                      }

--- a/assets/product-categories/frontblocks-product-categories-option.jsx
+++ b/assets/product-categories/frontblocks-product-categories-option.jsx
@@ -64,6 +64,17 @@ function ProductCategoriesEdit(props) {
       hoverTextColor,
       showButton,
       buttonText,
+      btnBgColor,
+      btnTextColor,
+      btnBorderColor,
+      btnBorderWidth,
+      btnBorderRadius,
+      btnFontSize,
+      btnPaddingV,
+      btnPaddingH,
+      btnHoverBgColor,
+      btnHoverTextColor,
+      btnHoverBorderColor,
       className,
    } = attributes;
 
@@ -116,6 +127,17 @@ function ProductCategoriesEdit(props) {
       '--frbl-hover-border-color': hoverBorderColor,
       '--frbl-hover-text-color': hoverTextColor,
       '--frbl-border-radius': `${borderRadius}px`,
+      '--frbl-btn-bg': btnBgColor || 'transparent',
+      '--frbl-btn-color': btnTextColor || 'currentColor',
+      '--frbl-btn-border-color': btnBorderColor || 'currentColor',
+      '--frbl-btn-border-width': `${btnBorderWidth}px`,
+      '--frbl-btn-border-radius': `${btnBorderRadius}px`,
+      '--frbl-btn-font-size': `${btnFontSize}px`,
+      '--frbl-btn-padding-v': `${btnPaddingV}px`,
+      '--frbl-btn-padding-h': `${btnPaddingH}px`,
+      '--frbl-btn-hover-bg': btnHoverBgColor || 'transparent',
+      '--frbl-btn-hover-color': btnHoverTextColor || 'currentColor',
+      '--frbl-btn-hover-border-color': btnHoverBorderColor || 'currentColor',
    };
 
    return (
@@ -270,6 +292,96 @@ function ProductCategoriesEdit(props) {
                   }}
                </TabPanel>
             </PanelBody>
+
+            { showButton && (
+               <PanelBody title={ __( 'Button Style', 'frontblocks' ) } initialOpen={ false }>
+                  <RangeControl
+                     label={ __( 'Font Size (px)', 'frontblocks' ) }
+                     value={ btnFontSize }
+                     onChange={ (v) => setAttributes({ btnFontSize: v }) }
+                     min={ 10 } max={ 40 }
+                  />
+                  <RangeControl
+                     label={ __( 'Padding Vertical (px)', 'frontblocks' ) }
+                     value={ btnPaddingV }
+                     onChange={ (v) => setAttributes({ btnPaddingV: v }) }
+                     min={ 0 } max={ 60 }
+                  />
+                  <RangeControl
+                     label={ __( 'Padding Horizontal (px)', 'frontblocks' ) }
+                     value={ btnPaddingH }
+                     onChange={ (v) => setAttributes({ btnPaddingH: v }) }
+                     min={ 0 } max={ 100 }
+                  />
+                  <RangeControl
+                     label={ __( 'Border Width (px)', 'frontblocks' ) }
+                     value={ btnBorderWidth }
+                     onChange={ (v) => setAttributes({ btnBorderWidth: v }) }
+                     min={ 0 } max={ 10 }
+                  />
+                  <RangeControl
+                     label={ __( 'Border Radius (px)', 'frontblocks' ) }
+                     value={ btnBorderRadius }
+                     onChange={ (v) => setAttributes({ btnBorderRadius: v }) }
+                     min={ 0 } max={ 50 }
+                  />
+
+                  <TabPanel
+                     className="frbl-style-tabs"
+                     tabs={ [
+                        { name: 'normal', title: __( 'Normal', 'frontblocks' ), className: 'tab-normal' },
+                        { name: 'hover',  title: __( 'Hover',  'frontblocks' ), className: 'tab-hover'  },
+                     ] }
+                  >
+                     { (tab) => {
+                        if ( tab.name === 'normal' ) {
+                           return (
+                              <Fragment>
+                                 <CompactColorPicker
+                                    label={ __( 'Background', 'frontblocks' ) }
+                                    color={ btnBgColor }
+                                    enableAlpha={ true }
+                                    onChangeComplete={ (v) => setAttributes({ btnBgColor: v.rgb ? `rgba(${v.rgb.r},${v.rgb.g},${v.rgb.b},${v.rgb.a})` : v.hex }) }
+                                 />
+                                 <CompactColorPicker
+                                    label={ __( 'Text Color', 'frontblocks' ) }
+                                    color={ btnTextColor }
+                                    onChangeComplete={ (v) => setAttributes({ btnTextColor: v.hex }) }
+                                 />
+                                 <CompactColorPicker
+                                    label={ __( 'Border Color', 'frontblocks' ) }
+                                    color={ btnBorderColor }
+                                    onChangeComplete={ (v) => setAttributes({ btnBorderColor: v.hex }) }
+                                 />
+                              </Fragment>
+                           );
+                        }
+                        if ( tab.name === 'hover' ) {
+                           return (
+                              <Fragment>
+                                 <CompactColorPicker
+                                    label={ __( 'Background', 'frontblocks' ) }
+                                    color={ btnHoverBgColor }
+                                    enableAlpha={ true }
+                                    onChangeComplete={ (v) => setAttributes({ btnHoverBgColor: v.rgb ? `rgba(${v.rgb.r},${v.rgb.g},${v.rgb.b},${v.rgb.a})` : v.hex }) }
+                                 />
+                                 <CompactColorPicker
+                                    label={ __( 'Text Color', 'frontblocks' ) }
+                                    color={ btnHoverTextColor }
+                                    onChangeComplete={ (v) => setAttributes({ btnHoverTextColor: v.hex }) }
+                                 />
+                                 <CompactColorPicker
+                                    label={ __( 'Border Color', 'frontblocks' ) }
+                                    color={ btnHoverBorderColor }
+                                    onChangeComplete={ (v) => setAttributes({ btnHoverBorderColor: v.hex }) }
+                                 />
+                              </Fragment>
+                           );
+                        }
+                     } }
+                  </TabPanel>
+               </PanelBody>
+            ) }
          </InspectorControls>
 
          <div {...blockProps}>
@@ -346,8 +458,19 @@ registerBlockType('frontblocks/product-categories', {
       hoverBgColor: { type: 'string', default: 'rgba(255, 255, 255, 0.7)' },
       hoverBorderColor: { type: 'string', default: '#555555' },
       hoverTextColor: { type: 'string', default: 'inherit' },
-      showButton: { type: 'boolean', default: false },
-      buttonText: { type: 'string', default: '' },
+      showButton:         { type: 'boolean', default: false },
+      buttonText:         { type: 'string',  default: '' },
+      btnBgColor:         { type: 'string',  default: 'transparent' },
+      btnTextColor:       { type: 'string',  default: '' },
+      btnBorderColor:     { type: 'string',  default: '' },
+      btnBorderWidth:     { type: 'number',  default: 2 },
+      btnBorderRadius:    { type: 'number',  default: 4 },
+      btnFontSize:        { type: 'number',  default: 14 },
+      btnPaddingV:        { type: 'number',  default: 10 },
+      btnPaddingH:        { type: 'number',  default: 20 },
+      btnHoverBgColor:    { type: 'string',  default: '' },
+      btnHoverTextColor:  { type: 'string',  default: '' },
+      btnHoverBorderColor:{ type: 'string',  default: '' },
    },
    edit: ProductCategoriesEdit,
    save: () => null,

--- a/assets/product-categories/frontblocks-product-categories-option.jsx
+++ b/assets/product-categories/frontblocks-product-categories-option.jsx
@@ -54,6 +54,7 @@ function ProductCategoriesEdit(props) {
       hideEmpty,
       showCount,
       columns,
+      imageSize,
       bgColor,
       borderColor,
       borderWidth,
@@ -198,6 +199,18 @@ function ProductCategoriesEdit(props) {
                   checked={showCount}
                   onChange={(newShowCount) => setAttributes({ showCount: newShowCount })}
                   help={__('Display the number of products in each category.', 'frontblocks')}
+               />
+
+               <SelectControl
+                  label={__('Image Size', 'frontblocks')}
+                  value={imageSize}
+                  options={[
+                     { label: __('Miniatura WooCommerce', 'frontblocks'), value: 'woocommerce_thumbnail' },
+                     { label: __('Imagen de producto (WooCommerce)', 'frontblocks'), value: 'woocommerce_single' },
+                     { label: __('Tamaño completo', 'frontblocks'), value: 'full' },
+                  ]}
+                  onChange={(val) => setAttributes({ imageSize: val })}
+                  help={__('Tamaño de imagen de cada categoría.', 'frontblocks')}
                />
 
             </PanelBody>
@@ -398,9 +411,16 @@ function ProductCategoriesEdit(props) {
             ) : (
                <div className="frbl-product-categories-grid" style={styleVars}>
                   {categories.map((category) => {
-                     const imageUrl = category.category_image && category.category_image.src 
-                        ? category.category_image.src 
-                        : 'https://placehold.co/600x400/eeeeee/333333?text=Product+Category';
+                     const imgData = category.category_image || {};
+                     let imageUrl;
+                     if ( imageSize === 'full' ) {
+                        imageUrl = imgData.full || imgData.src;
+                     } else if ( imageSize === 'woocommerce_single' ) {
+                        imageUrl = imgData.single || imgData.src;
+                     } else {
+                        imageUrl = imgData.src;
+                     }
+                     imageUrl = imageUrl || 'https://placehold.co/600x400/eeeeee/333333?text=Product+Category';
                      
                      return (
                         <div key={category.id} className={`frbl-category-item frbl-category-${category.slug}`}>
@@ -450,6 +470,7 @@ registerBlockType('frontblocks/product-categories', {
       showCount: { type: 'boolean', default: true },
       className: { type: 'string', default: '' },
       columns: { type: 'number', default: 2 },
+      imageSize: { type: 'string', default: 'woocommerce_thumbnail' },
       bgColor: { type: 'string', default: 'rgba(255, 255, 255, 0.5)' },
       borderColor: { type: 'string', default: '#dddddd' },
       borderWidth: { type: 'number', default: 1 },

--- a/assets/product-categories/frontblocks-product-categories-option.jsx
+++ b/assets/product-categories/frontblocks-product-categories-option.jsx
@@ -6,6 +6,7 @@ const {
    RangeControl,
    SelectControl,
    ToggleControl,
+   TextControl,
    ColorPicker,
    ColorIndicator,
    Dropdown,
@@ -46,10 +47,10 @@ function CompactColorPicker( { label, color, onChangeComplete, enableAlpha } ) {
 
 function ProductCategoriesEdit(props) {
    const { attributes, setAttributes } = props;
-   const { 
-      count, 
-      orderby, 
-      order, 
+   const {
+      count,
+      orderby,
+      order,
       hideEmpty,
       showCount,
       columns,
@@ -61,6 +62,8 @@ function ProductCategoriesEdit(props) {
       hoverBgColor,
       hoverBorderColor,
       hoverTextColor,
+      showButton,
+      buttonText,
       className,
    } = attributes;
 
@@ -174,6 +177,22 @@ function ProductCategoriesEdit(props) {
                   onChange={(newShowCount) => setAttributes({ showCount: newShowCount })}
                   help={__('Display the number of products in each category.', 'frontblocks')}
                />
+
+               <ToggleControl
+                  label={__('Show Button', 'frontblocks')}
+                  checked={showButton}
+                  onChange={(val) => setAttributes({ showButton: val })}
+                  help={__('Display a button at the bottom of each category card.', 'frontblocks')}
+               />
+
+               { showButton && (
+                  <TextControl
+                     label={__('Button Text', 'frontblocks')}
+                     value={buttonText}
+                     onChange={(val) => setAttributes({ buttonText: val })}
+                     placeholder={__('Shop now', 'frontblocks')}
+                  />
+               ) }
             </PanelBody>
 
             <PanelBody
@@ -275,8 +294,8 @@ function ProductCategoriesEdit(props) {
                         <div key={category.id} className={`frbl-category-item frbl-category-${category.slug}`}>
                            <div className="frbl-category-link">
                               <div className="frbl-category-image-wrap">
-                                 <img 
-                                    src={imageUrl} 
+                                 <img
+                                    src={imageUrl}
                                     alt={category.name}
                                     className="frbl-category-image"
                                  />
@@ -284,6 +303,11 @@ function ProductCategoriesEdit(props) {
                               <h3 className="frbl-category-name">
                                  {category.name}{showCount && ` (${category.count})`}
                               </h3>
+                              { showButton && (
+                                 <span className="frbl-category-button">
+                                    { buttonText || __( 'Shop now', 'frontblocks' ) }
+                                 </span>
+                              ) }
                            </div>
                         </div>
                      );
@@ -322,6 +346,8 @@ registerBlockType('frontblocks/product-categories', {
       hoverBgColor: { type: 'string', default: 'rgba(255, 255, 255, 0.7)' },
       hoverBorderColor: { type: 'string', default: '#555555' },
       hoverTextColor: { type: 'string', default: 'inherit' },
+      showButton: { type: 'boolean', default: false },
+      buttonText: { type: 'string', default: '' },
    },
    edit: ProductCategoriesEdit,
    save: () => null,

--- a/assets/product-categories/frontblocks-product-categories-option.jsx
+++ b/assets/product-categories/frontblocks-product-categories-option.jsx
@@ -432,7 +432,7 @@ function ProductCategoriesEdit(props) {
 }
 
 registerBlockType('frontblocks/product-categories', {
-   title: __('Product Categories', 'frontblocks'),
+   title: __('FrontBlocks: Product Categories', 'frontblocks'),
    description: __('Display a list of WooCommerce Product Categories.', 'frontblocks'),
    category: 'woocommerce', 
    icon: 'store', 

--- a/assets/product-categories/frontblocks-product-categories.css
+++ b/assets/product-categories/frontblocks-product-categories.css
@@ -54,19 +54,21 @@
 .frbl-product-categories-grid .frbl-category-button {
     display: block;
     margin: 16px 0;
-    padding: 10px 20px;
-    border: 2px solid var(--frbl-text-color, currentColor);
-    border-radius: 4px;
-    font-size: 0.875em;
+    padding: var(--frbl-btn-padding-v, 10px) var(--frbl-btn-padding-h, 20px);
+    background-color: var(--frbl-btn-bg, transparent);
+    color: var(--frbl-btn-color, currentColor);
+    border: var(--frbl-btn-border-width, 2px) solid var(--frbl-btn-border-color, currentColor);
+    border-radius: var(--frbl-btn-border-radius, 4px);
+    font-size: var(--frbl-btn-font-size, 14px);
     font-weight: 600;
     text-align: center;
     transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 .frbl-product-categories-grid .frbl-category-link:hover .frbl-category-button {
-    background-color: var(--frbl-hover-text-color, currentColor);
-    color: var(--frbl-hover-bg-color, #fff);
-    border-color: var(--frbl-hover-text-color, currentColor);
+    background-color: var(--frbl-btn-hover-bg, transparent);
+    color: var(--frbl-btn-hover-color, currentColor);
+    border-color: var(--frbl-btn-hover-border-color, currentColor);
 }
 
 html :where([style*=border-width]) {

--- a/assets/product-categories/frontblocks-product-categories.css
+++ b/assets/product-categories/frontblocks-product-categories.css
@@ -51,6 +51,24 @@
     display: block;
 }
 
+.frbl-product-categories-grid .frbl-category-button {
+    display: block;
+    margin: 16px 0;
+    padding: 10px 20px;
+    border: 2px solid var(--frbl-text-color, currentColor);
+    border-radius: 4px;
+    font-size: 0.875em;
+    font-weight: 600;
+    text-align: center;
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.frbl-product-categories-grid .frbl-category-link:hover .frbl-category-button {
+    background-color: var(--frbl-hover-text-color, currentColor);
+    color: var(--frbl-hover-bg-color, #fff);
+    border-color: var(--frbl-hover-text-color, currentColor);
+}
+
 html :where([style*=border-width]) {
     border-style: none;
 }

--- a/assets/product-categories/frontblocks-product-categories.js
+++ b/assets/product-categories/frontblocks-product-categories.js
@@ -94,6 +94,17 @@ function ProductCategoriesEdit(props) {
     hoverTextColor = attributes.hoverTextColor,
     showButton = attributes.showButton,
     buttonText = attributes.buttonText,
+    btnBgColor = attributes.btnBgColor,
+    btnTextColor = attributes.btnTextColor,
+    btnBorderColor = attributes.btnBorderColor,
+    btnBorderWidth = attributes.btnBorderWidth,
+    btnBorderRadius = attributes.btnBorderRadius,
+    btnFontSize = attributes.btnFontSize,
+    btnPaddingV = attributes.btnPaddingV,
+    btnPaddingH = attributes.btnPaddingH,
+    btnHoverBgColor = attributes.btnHoverBgColor,
+    btnHoverTextColor = attributes.btnHoverTextColor,
+    btnHoverBorderColor = attributes.btnHoverBorderColor,
     className = attributes.className;
   var _useState = useState([]),
     _useState2 = _slicedToArray(_useState, 2),
@@ -137,7 +148,18 @@ function ProductCategoriesEdit(props) {
     '--frbl-hover-bg-color': hoverBgColor,
     '--frbl-hover-border-color': hoverBorderColor,
     '--frbl-hover-text-color': hoverTextColor,
-    '--frbl-border-radius': "".concat(borderRadius, "px")
+    '--frbl-border-radius': "".concat(borderRadius, "px"),
+    '--frbl-btn-bg': btnBgColor || 'transparent',
+    '--frbl-btn-color': btnTextColor || 'currentColor',
+    '--frbl-btn-border-color': btnBorderColor || 'currentColor',
+    '--frbl-btn-border-width': "".concat(btnBorderWidth, "px"),
+    '--frbl-btn-border-radius': "".concat(btnBorderRadius, "px"),
+    '--frbl-btn-font-size': "".concat(btnFontSize, "px"),
+    '--frbl-btn-padding-v': "".concat(btnPaddingV, "px"),
+    '--frbl-btn-padding-h': "".concat(btnPaddingH, "px"),
+    '--frbl-btn-hover-bg': btnHoverBgColor || 'transparent',
+    '--frbl-btn-hover-color': btnHoverTextColor || 'currentColor',
+    '--frbl-btn-hover-border-color': btnHoverBorderColor || 'currentColor'
   };
   return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(InspectorControls, null, /*#__PURE__*/React.createElement(PanelBody, {
     title: __('Product Categories Settings', 'frontblocks'),
@@ -327,6 +349,127 @@ function ProductCategoriesEdit(props) {
         }
       }));
     }
+  })), showButton && /*#__PURE__*/React.createElement(PanelBody, {
+    title: __('Button Style', 'frontblocks'),
+    initialOpen: false
+  }, /*#__PURE__*/React.createElement(RangeControl, {
+    label: __('Font Size (px)', 'frontblocks'),
+    value: btnFontSize,
+    onChange: function onChange(v) {
+      return setAttributes({
+        btnFontSize: v
+      });
+    },
+    min: 10,
+    max: 40
+  }), /*#__PURE__*/React.createElement(RangeControl, {
+    label: __('Padding Vertical (px)', 'frontblocks'),
+    value: btnPaddingV,
+    onChange: function onChange(v) {
+      return setAttributes({
+        btnPaddingV: v
+      });
+    },
+    min: 0,
+    max: 60
+  }), /*#__PURE__*/React.createElement(RangeControl, {
+    label: __('Padding Horizontal (px)', 'frontblocks'),
+    value: btnPaddingH,
+    onChange: function onChange(v) {
+      return setAttributes({
+        btnPaddingH: v
+      });
+    },
+    min: 0,
+    max: 100
+  }), /*#__PURE__*/React.createElement(RangeControl, {
+    label: __('Border Width (px)', 'frontblocks'),
+    value: btnBorderWidth,
+    onChange: function onChange(v) {
+      return setAttributes({
+        btnBorderWidth: v
+      });
+    },
+    min: 0,
+    max: 10
+  }), /*#__PURE__*/React.createElement(RangeControl, {
+    label: __('Border Radius (px)', 'frontblocks'),
+    value: btnBorderRadius,
+    onChange: function onChange(v) {
+      return setAttributes({
+        btnBorderRadius: v
+      });
+    },
+    min: 0,
+    max: 50
+  }), /*#__PURE__*/React.createElement(TabPanel, {
+    className: "frbl-style-tabs",
+    tabs: [{
+      name: 'normal',
+      title: __('Normal', 'frontblocks'),
+      className: 'tab-normal'
+    }, {
+      name: 'hover',
+      title: __('Hover', 'frontblocks'),
+      className: 'tab-hover'
+    }]
+  }, function (tab) {
+    if (tab.name === 'normal') {
+      return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Background', 'frontblocks'),
+        color: btnBgColor,
+        enableAlpha: true,
+        onChangeComplete: function onChangeComplete(v) {
+          return setAttributes({
+            btnBgColor: v.rgb ? "rgba(".concat(v.rgb.r, ",").concat(v.rgb.g, ",").concat(v.rgb.b, ",").concat(v.rgb.a, ")") : v.hex
+          });
+        }
+      }), /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Text Color', 'frontblocks'),
+        color: btnTextColor,
+        onChangeComplete: function onChangeComplete(v) {
+          return setAttributes({
+            btnTextColor: v.hex
+          });
+        }
+      }), /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Border Color', 'frontblocks'),
+        color: btnBorderColor,
+        onChangeComplete: function onChangeComplete(v) {
+          return setAttributes({
+            btnBorderColor: v.hex
+          });
+        }
+      }));
+    }
+    if (tab.name === 'hover') {
+      return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Background', 'frontblocks'),
+        color: btnHoverBgColor,
+        enableAlpha: true,
+        onChangeComplete: function onChangeComplete(v) {
+          return setAttributes({
+            btnHoverBgColor: v.rgb ? "rgba(".concat(v.rgb.r, ",").concat(v.rgb.g, ",").concat(v.rgb.b, ",").concat(v.rgb.a, ")") : v.hex
+          });
+        }
+      }), /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Text Color', 'frontblocks'),
+        color: btnHoverTextColor,
+        onChangeComplete: function onChangeComplete(v) {
+          return setAttributes({
+            btnHoverTextColor: v.hex
+          });
+        }
+      }), /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Border Color', 'frontblocks'),
+        color: btnHoverBorderColor,
+        onChangeComplete: function onChangeComplete(v) {
+          return setAttributes({
+            btnHoverBorderColor: v.hex
+          });
+        }
+      }));
+    }
   }))), /*#__PURE__*/React.createElement("div", blockProps, isLoading ? /*#__PURE__*/React.createElement("div", {
     style: {
       textAlign: 'center',
@@ -439,6 +582,50 @@ registerBlockType('frontblocks/product-categories', {
       default: false
     },
     buttonText: {
+      type: 'string',
+      default: ''
+    },
+    btnBgColor: {
+      type: 'string',
+      default: 'transparent'
+    },
+    btnTextColor: {
+      type: 'string',
+      default: ''
+    },
+    btnBorderColor: {
+      type: 'string',
+      default: ''
+    },
+    btnBorderWidth: {
+      type: 'number',
+      default: 2
+    },
+    btnBorderRadius: {
+      type: 'number',
+      default: 4
+    },
+    btnFontSize: {
+      type: 'number',
+      default: 14
+    },
+    btnPaddingV: {
+      type: 'number',
+      default: 10
+    },
+    btnPaddingH: {
+      type: 'number',
+      default: 20
+    },
+    btnHoverBgColor: {
+      type: 'string',
+      default: ''
+    },
+    btnHoverTextColor: {
+      type: 'string',
+      default: ''
+    },
+    btnHoverBorderColor: {
       type: 'string',
       default: ''
     }

--- a/assets/product-categories/frontblocks-product-categories.js
+++ b/assets/product-categories/frontblocks-product-categories.js
@@ -84,6 +84,7 @@ function ProductCategoriesEdit(props) {
     hideEmpty = attributes.hideEmpty,
     showCount = attributes.showCount,
     columns = attributes.columns,
+    imageSize = attributes.imageSize,
     bgColor = attributes.bgColor,
     borderColor = attributes.borderColor,
     borderWidth = attributes.borderWidth,
@@ -239,6 +240,25 @@ function ProductCategoriesEdit(props) {
       });
     },
     help: __('Display the number of products in each category.', 'frontblocks')
+  }), /*#__PURE__*/React.createElement(SelectControl, {
+    label: __('Image Size', 'frontblocks'),
+    value: imageSize,
+    options: [{
+      label: __('Miniatura WooCommerce', 'frontblocks'),
+      value: 'woocommerce_thumbnail'
+    }, {
+      label: __('Imagen de producto (WooCommerce)', 'frontblocks'),
+      value: 'woocommerce_single'
+    }, {
+      label: __('Tamaño completo', 'frontblocks'),
+      value: 'full'
+    }],
+    onChange: function onChange(val) {
+      return setAttributes({
+        imageSize: val
+      });
+    },
+    help: __('Tamaño de imagen de cada categoría.', 'frontblocks')
   })), /*#__PURE__*/React.createElement(PanelBody, {
     title: __('Card Style Settings', 'frontblocks'),
     initialOpen: false
@@ -491,7 +511,16 @@ function ProductCategoriesEdit(props) {
     className: "frbl-product-categories-grid",
     style: styleVars
   }, categories.map(function (category) {
-    var imageUrl = category.category_image && category.category_image.src ? category.category_image.src : 'https://placehold.co/600x400/eeeeee/333333?text=Product+Category';
+    var imgData = category.category_image || {};
+    var imageUrl;
+    if (imageSize === 'full') {
+      imageUrl = imgData.full || imgData.src;
+    } else if (imageSize === 'woocommerce_single') {
+      imageUrl = imgData.single || imgData.src;
+    } else {
+      imageUrl = imgData.src;
+    }
+    imageUrl = imageUrl || 'https://placehold.co/600x400/eeeeee/333333?text=Product+Category';
     return /*#__PURE__*/React.createElement("div", {
       key: category.id,
       className: "frbl-category-item frbl-category-".concat(category.slug)
@@ -544,6 +573,10 @@ registerBlockType('frontblocks/product-categories', {
     columns: {
       type: 'number',
       default: 2
+    },
+    imageSize: {
+      type: 'string',
+      default: 'woocommerce_thumbnail'
     },
     bgColor: {
       type: 'string',

--- a/assets/product-categories/frontblocks-product-categories.js
+++ b/assets/product-categories/frontblocks-product-categories.js
@@ -511,7 +511,7 @@ function ProductCategoriesEdit(props) {
   }))));
 }
 registerBlockType('frontblocks/product-categories', {
-  title: __('Product Categories', 'frontblocks'),
+  title: __('FrontBlocks: Product Categories', 'frontblocks'),
   description: __('Display a list of WooCommerce Product Categories.', 'frontblocks'),
   category: 'woocommerce',
   icon: 'store',

--- a/assets/product-categories/frontblocks-product-categories.js
+++ b/assets/product-categories/frontblocks-product-categories.js
@@ -239,24 +239,6 @@ function ProductCategoriesEdit(props) {
       });
     },
     help: __('Display the number of products in each category.', 'frontblocks')
-  }), /*#__PURE__*/React.createElement(ToggleControl, {
-    label: __('Show Button', 'frontblocks'),
-    checked: showButton,
-    onChange: function onChange(val) {
-      return setAttributes({
-        showButton: val
-      });
-    },
-    help: __('Display a button at the bottom of each category card.', 'frontblocks')
-  }), showButton && /*#__PURE__*/React.createElement(TextControl, {
-    label: __('Button Text', 'frontblocks'),
-    value: buttonText,
-    onChange: function onChange(val) {
-      return setAttributes({
-        buttonText: val
-      });
-    },
-    placeholder: __('Shop now', 'frontblocks')
   })), /*#__PURE__*/React.createElement(PanelBody, {
     title: __('Card Style Settings', 'frontblocks'),
     initialOpen: false
@@ -349,10 +331,28 @@ function ProductCategoriesEdit(props) {
         }
       }));
     }
-  })), showButton && /*#__PURE__*/React.createElement(PanelBody, {
+  })), /*#__PURE__*/React.createElement(PanelBody, {
     title: __('Button Style', 'frontblocks'),
     initialOpen: false
-  }, /*#__PURE__*/React.createElement(RangeControl, {
+  }, /*#__PURE__*/React.createElement(ToggleControl, {
+    label: __('Show Button', 'frontblocks'),
+    checked: showButton,
+    onChange: function onChange(val) {
+      return setAttributes({
+        showButton: val
+      });
+    },
+    help: __('Display a button at the bottom of each category card.', 'frontblocks')
+  }), showButton && /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(TextControl, {
+    label: __('Button Text', 'frontblocks'),
+    value: buttonText,
+    onChange: function onChange(val) {
+      return setAttributes({
+        buttonText: val
+      });
+    },
+    placeholder: __('Shop now', 'frontblocks')
+  }), /*#__PURE__*/React.createElement(RangeControl, {
     label: __('Font Size (px)', 'frontblocks'),
     value: btnFontSize,
     onChange: function onChange(v) {
@@ -470,7 +470,7 @@ function ProductCategoriesEdit(props) {
         }
       }));
     }
-  }))), /*#__PURE__*/React.createElement("div", blockProps, isLoading ? /*#__PURE__*/React.createElement("div", {
+  })))), /*#__PURE__*/React.createElement("div", blockProps, isLoading ? /*#__PURE__*/React.createElement("div", {
     style: {
       textAlign: 'center',
       padding: '40px'

--- a/assets/product-categories/frontblocks-product-categories.js
+++ b/assets/product-categories/frontblocks-product-categories.js
@@ -19,6 +19,7 @@ var _wp$components = wp.components,
   RangeControl = _wp$components.RangeControl,
   SelectControl = _wp$components.SelectControl,
   ToggleControl = _wp$components.ToggleControl,
+  TextControl = _wp$components.TextControl,
   ColorPicker = _wp$components.ColorPicker,
   ColorIndicator = _wp$components.ColorIndicator,
   Dropdown = _wp$components.Dropdown,
@@ -91,6 +92,8 @@ function ProductCategoriesEdit(props) {
     hoverBgColor = attributes.hoverBgColor,
     hoverBorderColor = attributes.hoverBorderColor,
     hoverTextColor = attributes.hoverTextColor,
+    showButton = attributes.showButton,
+    buttonText = attributes.buttonText,
     className = attributes.className;
   var _useState = useState([]),
     _useState2 = _slicedToArray(_useState, 2),
@@ -214,6 +217,24 @@ function ProductCategoriesEdit(props) {
       });
     },
     help: __('Display the number of products in each category.', 'frontblocks')
+  }), /*#__PURE__*/React.createElement(ToggleControl, {
+    label: __('Show Button', 'frontblocks'),
+    checked: showButton,
+    onChange: function onChange(val) {
+      return setAttributes({
+        showButton: val
+      });
+    },
+    help: __('Display a button at the bottom of each category card.', 'frontblocks')
+  }), showButton && /*#__PURE__*/React.createElement(TextControl, {
+    label: __('Button Text', 'frontblocks'),
+    value: buttonText,
+    onChange: function onChange(val) {
+      return setAttributes({
+        buttonText: val
+      });
+    },
+    placeholder: __('Shop now', 'frontblocks')
   })), /*#__PURE__*/React.createElement(PanelBody, {
     title: __('Card Style Settings', 'frontblocks'),
     initialOpen: false
@@ -341,7 +362,9 @@ function ProductCategoriesEdit(props) {
       className: "frbl-category-image"
     })), /*#__PURE__*/React.createElement("h3", {
       className: "frbl-category-name"
-    }, category.name, showCount && " (".concat(category.count, ")"))));
+    }, category.name, showCount && " (".concat(category.count, ")")), showButton && /*#__PURE__*/React.createElement("span", {
+      className: "frbl-category-button"
+    }, buttonText || __('Shop now', 'frontblocks'))));
   }))));
 }
 registerBlockType('frontblocks/product-categories', {
@@ -410,6 +433,14 @@ registerBlockType('frontblocks/product-categories', {
     hoverTextColor: {
       type: 'string',
       default: 'inherit'
+    },
+    showButton: {
+      type: 'boolean',
+      default: false
+    },
+    buttonText: {
+      type: 'string',
+      default: ''
     }
   },
   edit: ProductCategoriesEdit,

--- a/assets/product-categories/frontblocks-product-categories.js
+++ b/assets/product-categories/frontblocks-product-categories.js
@@ -20,10 +20,60 @@ var _wp$components = wp.components,
   SelectControl = _wp$components.SelectControl,
   ToggleControl = _wp$components.ToggleControl,
   ColorPicker = _wp$components.ColorPicker,
+  ColorIndicator = _wp$components.ColorIndicator,
+  Dropdown = _wp$components.Dropdown,
+  Button = _wp$components.Button,
   TabPanel = _wp$components.TabPanel,
   Spinner = _wp$components.Spinner;
 var __ = wp.i18n.__;
 var apiFetch = wp.apiFetch;
+function CompactColorPicker(_ref) {
+  var label = _ref.label,
+    color = _ref.color,
+    onChangeComplete = _ref.onChangeComplete,
+    enableAlpha = _ref.enableAlpha;
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: '12px'
+    }
+  }, /*#__PURE__*/React.createElement("span", {
+    style: {
+      fontSize: '12px'
+    }
+  }, label), /*#__PURE__*/React.createElement(Dropdown, {
+    renderToggle: function renderToggle(_ref2) {
+      var isOpen = _ref2.isOpen,
+        onToggle = _ref2.onToggle;
+      return /*#__PURE__*/React.createElement(Button, {
+        onClick: onToggle,
+        "aria-expanded": isOpen,
+        style: {
+          padding: 0,
+          minWidth: 0,
+          background: 'none',
+          border: 'none',
+          boxShadow: 'none'
+        }
+      }, /*#__PURE__*/React.createElement(ColorIndicator, {
+        colorValue: color || 'transparent'
+      }));
+    },
+    renderContent: function renderContent() {
+      return /*#__PURE__*/React.createElement("div", {
+        style: {
+          padding: '8px'
+        }
+      }, /*#__PURE__*/React.createElement(ColorPicker, {
+        color: color,
+        onChangeComplete: onChangeComplete,
+        disableAlpha: !enableAlpha
+      }));
+    }
+  }));
+}
 function ProductCategoriesEdit(props) {
   var attributes = props.attributes,
     setAttributes = props.setAttributes;
@@ -55,9 +105,6 @@ function ProductCategoriesEdit(props) {
   });
   var countHelpText = count === 999 ? __('Currently set to show ALL categories.', 'frontblocks') : __('Number of categories shown. Set to 999 to show all.', 'frontblocks');
   var countLabel = count === 999 ? __('Number of Categories (All)', 'frontblocks') : __('Number of Categories', 'frontblocks');
-  var colorPickerCompactStyle = {
-    maxWidth: '250px'
-  };
 
   // Load categories from API.
   useEffect(function () {
@@ -204,90 +251,60 @@ function ProductCategoriesEdit(props) {
     }]
   }, function (tab) {
     if (tab.name === 'normal') {
-      return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement("h4", {
-        style: {
-          marginTop: '15px'
-        }
-      }, __('Background Color', 'frontblocks')), /*#__PURE__*/React.createElement("div", {
-        style: colorPickerCompactStyle
-      }, /*#__PURE__*/React.createElement(ColorPicker, {
+      return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Background Color', 'frontblocks'),
         color: bgColor,
+        enableAlpha: true,
         onChangeComplete: function onChangeComplete(value) {
           return setAttributes({
             bgColor: value.rgb ? "rgba(".concat(value.rgb.r, ", ").concat(value.rgb.g, ", ").concat(value.rgb.b, ", ").concat(value.rgb.a, ")") : value.hex
           });
-        },
-        disableAlpha: false
-      })), /*#__PURE__*/React.createElement("h4", {
-        style: {
-          marginTop: '15px'
         }
-      }, __('Border Color', 'frontblocks')), /*#__PURE__*/React.createElement("div", {
-        style: colorPickerCompactStyle
-      }, /*#__PURE__*/React.createElement(ColorPicker, {
+      }), /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Border Color', 'frontblocks'),
         color: borderColor,
         onChangeComplete: function onChangeComplete(value) {
           return setAttributes({
             borderColor: value.hex
           });
         }
-      })), /*#__PURE__*/React.createElement("h4", {
-        style: {
-          marginTop: '15px'
-        }
-      }, __('Text Color', 'frontblocks')), /*#__PURE__*/React.createElement("div", {
-        style: colorPickerCompactStyle
-      }, /*#__PURE__*/React.createElement(ColorPicker, {
+      }), /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Text Color', 'frontblocks'),
         color: textColor,
         onChangeComplete: function onChangeComplete(value) {
           return setAttributes({
             textColor: value.hex
           });
         }
-      })));
+      }));
     }
     if (tab.name === 'hover') {
-      return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement("h4", {
-        style: {
-          marginTop: '15px'
-        }
-      }, __('Hover Background Color', 'frontblocks')), /*#__PURE__*/React.createElement("div", {
-        style: colorPickerCompactStyle
-      }, /*#__PURE__*/React.createElement(ColorPicker, {
+      return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Hover Background Color', 'frontblocks'),
         color: hoverBgColor,
+        enableAlpha: true,
         onChangeComplete: function onChangeComplete(value) {
           return setAttributes({
             hoverBgColor: value.rgb ? "rgba(".concat(value.rgb.r, ", ").concat(value.rgb.g, ", ").concat(value.rgb.b, ", ").concat(value.rgb.a, ")") : value.hex
           });
-        },
-        disableAlpha: false
-      })), /*#__PURE__*/React.createElement("h4", {
-        style: {
-          marginTop: '15px'
         }
-      }, __('Hover Border Color', 'frontblocks')), /*#__PURE__*/React.createElement("div", {
-        style: colorPickerCompactStyle
-      }, /*#__PURE__*/React.createElement(ColorPicker, {
+      }), /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Hover Border Color', 'frontblocks'),
         color: hoverBorderColor,
         onChangeComplete: function onChangeComplete(value) {
           return setAttributes({
             hoverBorderColor: value.hex
           });
         }
-      })), /*#__PURE__*/React.createElement("h4", {
-        style: {
-          marginTop: '15px'
-        }
-      }, __('Hover Text Color', 'frontblocks')), /*#__PURE__*/React.createElement("div", {
-        style: colorPickerCompactStyle
-      }, /*#__PURE__*/React.createElement(ColorPicker, {
+      }), /*#__PURE__*/React.createElement(CompactColorPicker, {
+        label: __('Hover Text Color', 'frontblocks'),
         color: hoverTextColor,
         onChangeComplete: function onChangeComplete(value) {
           return setAttributes({
             hoverTextColor: value.hex
           });
         }
-      })));
+      }));
     }
   }))), /*#__PURE__*/React.createElement("div", blockProps, isLoading ? /*#__PURE__*/React.createElement("div", {
     style: {

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1242,7 +1242,7 @@ class Settings {
 		<!-- Select and description - will be moved below the card by JavaScript -->
 		<div id="events-type-wrapper" class="tw-mt-4" style="<?php echo $enabled ? 'width: 100%; min-width: 100%; display: block;' : 'display: none;'; ?>">
 			<label for="<?php echo esc_attr( $this->option_events_type ); ?>" class="tw-block tw-text-sm tw-font-medium tw-text-gray-700 tw-mb-2">
-				<?php echo esc_html__( 'Tipo de eventos', 'frontblocks' ); ?>
+				<?php echo esc_html__( 'Event type', 'frontblocks' ); ?>
 			</label>
 			<select 
 				id="<?php echo esc_attr( $this->option_events_type ); ?>" 
@@ -1254,11 +1254,11 @@ class Settings {
 					<?php echo esc_html__( 'Custom Post Type (CPT)', 'frontblocks' ); ?>
 				</option>
 				<option value="posts" <?php selected( $events_type, 'posts' ); ?>>
-					<?php echo esc_html__( 'Entradas de blog', 'frontblocks' ); ?>
+					<?php echo esc_html__( 'Blog posts', 'frontblocks' ); ?>
 				</option>
 			</select>
 			<p class="tw-text-xs tw-text-gray-500 tw-mt-2">
-				<?php echo esc_html__( 'Elige si los eventos se crearán en un CPT dedicado o en las entradas de blog normales.', 'frontblocks' ); ?>
+				<?php echo esc_html__( 'Choose whether events will be created in a dedicated CPT or in regular blog posts.', 'frontblocks' ); ?>
 			</p>
 		</div>
 		<?php
@@ -1479,7 +1479,7 @@ class Settings {
 								id="frbl-create-cpt-btn" 
 								class="tw-px-4 tw-py-2 tw-bg-primary-500 tw-text-white tw-rounded-lg hover:tw-bg-primary-600 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-500 tw-transition-colors"
 							>
-								<?php echo esc_html__( 'Crear', 'frontblocks' ); ?>
+								<?php echo esc_html__( 'Create', 'frontblocks' ); ?>
 							</button>
 						</div>
 						<p class="tw-text-xs tw-text-gray-500 tw-mt-2">

--- a/includes/Frontend/Events.php
+++ b/includes/Frontend/Events.php
@@ -84,21 +84,21 @@ class Events {
 	 */
 	public function register_cpt_event() {
 		$labels = array(
-			'name'          => __( 'Eventos', 'frontblocks' ),
-			'singular_name' => __( 'Evento', 'frontblocks' ),
-			'menu_name'     => __( 'Eventos', 'frontblocks' ),
-			'all_items'     => __( 'Todos los eventos', 'frontblocks' ),
-			'add_new'       => __( 'Añadir evento', 'frontblocks' ),
-			'add_new_item'  => __( 'Añadir nuevo evento', 'frontblocks' ),
-			'edit_item'     => __( 'Editar evento', 'frontblocks' ),
-			'new_item'      => __( 'Nuevo evento', 'frontblocks' ),
-			'view_item'     => __( 'Ver evento', 'frontblocks' ),
-			'search_items'  => __( 'Buscar evento', 'frontblocks' ),
-			'not_found'     => __( 'No se han encontrado eventos', 'frontblocks' ),
+			'name'          => __( 'Events', 'frontblocks' ),
+			'singular_name' => __( 'Event', 'frontblocks' ),
+			'menu_name'     => __( 'Events', 'frontblocks' ),
+			'all_items'     => __( 'All events', 'frontblocks' ),
+			'add_new'       => __( 'Add event', 'frontblocks' ),
+			'add_new_item'  => __( 'Add new event', 'frontblocks' ),
+			'edit_item'     => __( 'Edit event', 'frontblocks' ),
+			'new_item'      => __( 'New event', 'frontblocks' ),
+			'view_item'     => __( 'View event', 'frontblocks' ),
+			'search_items'  => __( 'Search event', 'frontblocks' ),
+			'not_found'     => __( 'No events found', 'frontblocks' ),
 		);
 
 		$args = array(
-			'label'         => __( 'Eventos', 'frontblocks' ),
+			'label'         => __( 'Events', 'frontblocks' ),
 			'labels'        => $labels,
 			'public'        => true,
 			'show_ui'       => true,
@@ -121,13 +121,13 @@ class Events {
 	 */
 	public function register_taxonomy_event_category() {
 		$labels = array(
-			'name'          => __( 'Categorías de eventos', 'frontblocks' ),
-			'singular_name' => __( 'Categoría', 'frontblocks' ),
-			'menu_name'     => __( 'Categorías', 'frontblocks' ),
+			'name'          => __( 'Event categories', 'frontblocks' ),
+			'singular_name' => __( 'Category', 'frontblocks' ),
+			'menu_name'     => __( 'Categories', 'frontblocks' ),
 		);
 
 		$args = array(
-			'label'             => __( 'Categorías', 'frontblocks' ),
+			'label'             => __( 'Categories', 'frontblocks' ),
 			'labels'            => $labels,
 			'public'            => true,
 			'hierarchical'      => true,
@@ -151,7 +151,7 @@ class Events {
 	public function add_metaboxes() {
 		add_meta_box(
 			'frbl_event_metabox',
-			__( 'Datos del Evento', 'frontblocks' ),
+			__( 'Event Data', 'frontblocks' ),
 			array( $this, 'render_metabox' ),
 			'event',
 			'normal',
@@ -167,7 +167,7 @@ class Events {
 	public function add_metaboxes_posts() {
 		add_meta_box(
 			'frbl_event_metabox',
-			__( 'Datos del Evento', 'frontblocks' ),
+			__( 'Event Data', 'frontblocks' ),
 			array( $this, 'render_metabox' ),
 			'post',
 			'normal',
@@ -238,47 +238,47 @@ class Events {
 		<div id="frbl_event_metabox" class="frbl-grid">
 
 			<div class="frbl-field">
-				<label><?php esc_html_e( 'Evento todo el día', 'frontblocks' ); ?></label>
+				<label><?php esc_html_e( 'All day event', 'frontblocks' ); ?></label>
 				<input type="checkbox" name="all_day" value="1" <?php checked( $all_day, '1' ); ?> />
 			</div>
 
 			<div class="frbl-field">
-				<label><?php esc_html_e( 'Coste', 'frontblocks' ); ?></label>
+				<label><?php esc_html_e( 'Cost', 'frontblocks' ); ?></label>
 				<input type="number" step="0.01" name="cost" value="<?php echo esc_attr( $cost ); ?>">
 			</div>
 
 			<div class="frbl-field">
-				<label><?php esc_html_e( 'Fecha inicio', 'frontblocks' ); ?></label>
+				<label><?php esc_html_e( 'Start date', 'frontblocks' ); ?></label>
 				<input type="date" name="start_date" value="<?php echo esc_attr( $start_date ); ?>">
 			</div>
 
 			<div class="frbl-field">
-				<label><?php esc_html_e( 'Hora inicio', 'frontblocks' ); ?></label>
+				<label><?php esc_html_e( 'Start time', 'frontblocks' ); ?></label>
 				<input type="time" name="start_time" value="<?php echo esc_attr( $start_time ); ?>">
 			</div>
 
 			<div class="frbl-field">
-				<label><?php esc_html_e( 'Fecha fin', 'frontblocks' ); ?></label>
+				<label><?php esc_html_e( 'End date', 'frontblocks' ); ?></label>
 				<input type="date" name="end_date" value="<?php echo esc_attr( $end_date ); ?>">
 			</div>
 
 			<div class="frbl-field">
-				<label><?php esc_html_e( 'Hora fin', 'frontblocks' ); ?></label>
+				<label><?php esc_html_e( 'End time', 'frontblocks' ); ?></label>
 				<input type="time" name="end_time" value="<?php echo esc_attr( $end_time ); ?>">
 			</div>
 
 			<div class="frbl-field">
-				<label><?php esc_html_e( 'Web del evento', 'frontblocks' ); ?></label>
+				<label><?php esc_html_e( 'Event website', 'frontblocks' ); ?></label>
 				<input type="url" name="web" value="<?php echo esc_attr( $web ); ?>">
 			</div>
 
 			<div class="frbl-field">
-				<label><?php esc_html_e( 'Póster del evento (url)', 'frontblocks' ); ?></label>
+				<label><?php esc_html_e( 'Event poster (url)', 'frontblocks' ); ?></label>
 				<input type="url" name="poster_evento" value="<?php echo esc_attr( $poster_evento ); ?>">
 			</div>
 
 			<div class="frbl-field full">
-				<label><?php esc_html_e( 'Dirección', 'frontblocks' ); ?></label>
+				<label><?php esc_html_e( 'Address', 'frontblocks' ); ?></label>
 				<input type="text" name="direccion_evento" value="<?php echo esc_attr( $direccion_evento ); ?>" style="max-width:100%;">
 			</div>
 

--- a/includes/Frontend/ProductCategories.php
+++ b/includes/Frontend/ProductCategories.php
@@ -76,19 +76,28 @@ class ProductCategories {
 		$thumbnail_id = get_term_meta( $term_data['id'], 'thumbnail_id', true );
 
 		if ( $thumbnail_id ) {
-			$image_url = wp_get_attachment_image_url( $thumbnail_id, 'woocommerce_thumbnail' );
-			if ( $image_url ) {
+			$src    = wp_get_attachment_image_url( $thumbnail_id, 'woocommerce_thumbnail' );
+			$single = wp_get_attachment_image_url( $thumbnail_id, 'woocommerce_single' );
+			$full   = wp_get_attachment_image_url( $thumbnail_id, 'full' );
+
+			if ( $src ) {
 				return array(
-					'src' => $image_url,
-					'id'  => $thumbnail_id,
+					'src'    => $src,
+					'single' => $single ?: $src,
+					'full'   => $full ?: $src,
+					'id'     => $thumbnail_id,
 				);
 			}
 		}
 
-		if ( function_exists( 'wc_placeholder_img_src' ) ) {
+		$placeholder = function_exists( 'wc_placeholder_img_src' ) ? wc_placeholder_img_src() : null;
+
+		if ( $placeholder ) {
 			return array(
-				'src' => wc_placeholder_img_src(),
-				'id'  => 0,
+				'src'    => $placeholder,
+				'single' => $placeholder,
+				'full'   => $placeholder,
+				'id'     => 0,
 			);
 		}
 
@@ -192,6 +201,10 @@ class ProductCategories {
 				'columns'             => array(
 					'type'    => 'number',
 					'default' => 2,
+				),
+				'imageSize'           => array(
+					'type'    => 'string',
+					'default' => 'woocommerce_thumbnail',
 				),
 				'bgColor'             => array(
 					'type'    => 'string',
@@ -305,6 +318,11 @@ class ProductCategories {
 		$hide_empty = $attributes['hideEmpty'] ?? false;
 		$show_count = $attributes['showCount'] ?? true;
 		$columns    = absint( $attributes['columns'] ?? 2 );
+		$image_size = sanitize_key( $attributes['imageSize'] ?? 'woocommerce_thumbnail' );
+		$allowed_sizes = array( 'woocommerce_thumbnail', 'woocommerce_single', 'full', 'large', 'medium' );
+		if ( ! in_array( $image_size, $allowed_sizes, true ) ) {
+			$image_size = 'woocommerce_thumbnail';
+		}
 
 		$bg_color               = sanitize_text_field( $attributes['bgColor'] ?? 'rgba(255, 255, 255, 0.5)' );
 		$border_color           = sanitize_text_field( $attributes['borderColor'] ?? '#dddddd' );
@@ -389,11 +407,15 @@ class ProductCategories {
 				$thumbnail_id = get_term_meta( $category->term_id, 'thumbnail_id', true );
 
 				if ( $thumbnail_id ) {
-					$image_url = wp_get_attachment_image_url( $thumbnail_id, 'woocommerce_thumbnail' );
-				} elseif ( function_exists( 'wc_placeholder_img_src' ) ) {
-					$image_url = wc_placeholder_img_src();
-				} else {
-					$image_url = 'https://placehold.co/600x400/eeeeee/333333?text=Product+Category';
+					$image_url = wp_get_attachment_image_url( $thumbnail_id, $image_size );
+				}
+
+				if ( empty( $image_url ) ) {
+					if ( function_exists( 'wc_placeholder_img_src' ) ) {
+						$image_url = wc_placeholder_img_src();
+					} else {
+						$image_url = 'https://placehold.co/600x400/eeeeee/333333?text=Product+Category';
+					}
 				}
 
 				$link = esc_url( get_term_link( $category, 'product_cat' ) );

--- a/includes/Frontend/ProductCategories.php
+++ b/includes/Frontend/ProductCategories.php
@@ -225,6 +225,14 @@ class ProductCategories {
 					'type'    => 'string',
 					'default' => 'inherit',
 				),
+				'showButton'       => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
+				'buttonText'       => array(
+					'type'    => 'string',
+					'default' => '',
+				),
 			),
 		);
 
@@ -262,6 +270,8 @@ class ProductCategories {
 		$hover_bg_color     = sanitize_text_field( $attributes['hoverBgColor'] ?? 'rgba(255, 255, 255, 0.7)' );
 		$hover_border_color = sanitize_text_field( $attributes['hoverBorderColor'] ?? '#555555' );
 		$hover_text_color   = sanitize_text_field( $attributes['hoverTextColor'] ?? 'inherit' );
+		$show_button        = ! empty( $attributes['showButton'] );
+		$button_text        = sanitize_text_field( $attributes['buttonText'] ?? '' );
 
 		/**
 		 * Lógica para "Mostrar todas"
@@ -334,6 +344,11 @@ class ProductCategories {
 						<h3 class="frbl-category-name">
 							<?php echo esc_html( $category->name ); ?><?php echo $show_count ? ' (' . esc_html( $category->count ) . ')' : ''; ?>
 						</h3>
+						<?php if ( $show_button ) : ?>
+							<span class="frbl-category-button">
+								<?php echo esc_html( $button_text ? $button_text : __( 'Shop now', 'frontblocks' ) ); ?>
+							</span>
+						<?php endif; ?>
 					</a>
 				</div>
 			<?php endforeach; ?>

--- a/includes/Frontend/ProductCategories.php
+++ b/includes/Frontend/ProductCategories.php
@@ -225,11 +225,55 @@ class ProductCategories {
 					'type'    => 'string',
 					'default' => 'inherit',
 				),
-				'showButton'       => array(
+				'showButton'          => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),
-				'buttonText'       => array(
+				'buttonText'          => array(
+					'type'    => 'string',
+					'default' => '',
+				),
+				'btnBgColor'          => array(
+					'type'    => 'string',
+					'default' => 'transparent',
+				),
+				'btnTextColor'        => array(
+					'type'    => 'string',
+					'default' => '',
+				),
+				'btnBorderColor'      => array(
+					'type'    => 'string',
+					'default' => '',
+				),
+				'btnBorderWidth'      => array(
+					'type'    => 'number',
+					'default' => 2,
+				),
+				'btnBorderRadius'     => array(
+					'type'    => 'number',
+					'default' => 4,
+				),
+				'btnFontSize'         => array(
+					'type'    => 'number',
+					'default' => 14,
+				),
+				'btnPaddingV'         => array(
+					'type'    => 'number',
+					'default' => 10,
+				),
+				'btnPaddingH'         => array(
+					'type'    => 'number',
+					'default' => 20,
+				),
+				'btnHoverBgColor'     => array(
+					'type'    => 'string',
+					'default' => '',
+				),
+				'btnHoverTextColor'   => array(
+					'type'    => 'string',
+					'default' => '',
+				),
+				'btnHoverBorderColor' => array(
 					'type'    => 'string',
 					'default' => '',
 				),
@@ -270,8 +314,19 @@ class ProductCategories {
 		$hover_bg_color     = sanitize_text_field( $attributes['hoverBgColor'] ?? 'rgba(255, 255, 255, 0.7)' );
 		$hover_border_color = sanitize_text_field( $attributes['hoverBorderColor'] ?? '#555555' );
 		$hover_text_color   = sanitize_text_field( $attributes['hoverTextColor'] ?? 'inherit' );
-		$show_button        = ! empty( $attributes['showButton'] );
-		$button_text        = sanitize_text_field( $attributes['buttonText'] ?? '' );
+		$show_button           = ! empty( $attributes['showButton'] );
+		$button_text           = sanitize_text_field( $attributes['buttonText'] ?? '' );
+		$btn_bg_color          = sanitize_text_field( $attributes['btnBgColor'] ?? 'transparent' );
+		$btn_text_color        = sanitize_text_field( $attributes['btnTextColor'] ?? '' );
+		$btn_border_color      = sanitize_text_field( $attributes['btnBorderColor'] ?? '' );
+		$btn_border_width      = absint( $attributes['btnBorderWidth'] ?? 2 );
+		$btn_border_radius     = absint( $attributes['btnBorderRadius'] ?? 4 );
+		$btn_font_size         = absint( $attributes['btnFontSize'] ?? 14 );
+		$btn_padding_v         = absint( $attributes['btnPaddingV'] ?? 10 );
+		$btn_padding_h         = absint( $attributes['btnPaddingH'] ?? 20 );
+		$btn_hover_bg_color    = sanitize_text_field( $attributes['btnHoverBgColor'] ?? '' );
+		$btn_hover_text_color  = sanitize_text_field( $attributes['btnHoverTextColor'] ?? '' );
+		$btn_hover_border_color = sanitize_text_field( $attributes['btnHoverBorderColor'] ?? '' );
 
 		/**
 		 * Lógica para "Mostrar todas"
@@ -303,7 +358,7 @@ class ProductCategories {
 		}
 
 		$style_vars = sprintf(
-			'--frbl-grid-columns: %d; --frbl-bg-color: %s; --frbl-border-color: %s; --frbl-border-width: %dpx; --frbl-text-color: %s; --frbl-hover-bg-color: %s; --frbl-hover-border-color: %s; --frbl-hover-text-color: %s; --frbl-border-radius: %dpx;',
+			'--frbl-grid-columns:%d;--frbl-bg-color:%s;--frbl-border-color:%s;--frbl-border-width:%dpx;--frbl-text-color:%s;--frbl-hover-bg-color:%s;--frbl-hover-border-color:%s;--frbl-hover-text-color:%s;--frbl-border-radius:%dpx;--frbl-btn-bg:%s;--frbl-btn-color:%s;--frbl-btn-border-color:%s;--frbl-btn-border-width:%dpx;--frbl-btn-border-radius:%dpx;--frbl-btn-font-size:%dpx;--frbl-btn-padding-v:%dpx;--frbl-btn-padding-h:%dpx;--frbl-btn-hover-bg:%s;--frbl-btn-hover-color:%s;--frbl-btn-hover-border-color:%s;',
 			$columns,
 			$bg_color,
 			$border_color,
@@ -312,7 +367,18 @@ class ProductCategories {
 			$hover_bg_color,
 			$hover_border_color,
 			$hover_text_color,
-			$border_radius
+			$border_radius,
+			$btn_bg_color,
+			$btn_text_color ? $btn_text_color : 'currentColor',
+			$btn_border_color ? $btn_border_color : 'currentColor',
+			$btn_border_width,
+			$btn_border_radius,
+			$btn_font_size,
+			$btn_padding_v,
+			$btn_padding_h,
+			$btn_hover_bg_color ? $btn_hover_bg_color : 'transparent',
+			$btn_hover_text_color ? $btn_hover_text_color : 'currentColor',
+			$btn_hover_border_color ? $btn_hover_border_color : 'currentColor'
 		);
 
 		ob_start();

--- a/includes/Frontend/ProductCategories.php
+++ b/includes/Frontend/ProductCategories.php
@@ -83,8 +83,8 @@ class ProductCategories {
 			if ( $src ) {
 				return array(
 					'src'    => $src,
-					'single' => $single ?: $src,
-					'full'   => $full ?: $src,
+					'single' => $single ? $single : $src,
+					'full'   => $full ? $full : $src,
 					'id'     => $thumbnail_id,
 				);
 			}
@@ -312,13 +312,13 @@ class ProductCategories {
 			return '';
 		}
 
-		$count      = absint( $attributes['count'] ?? 5 );
-		$orderby    = sanitize_key( $attributes['orderby'] ?? 'count' );
-		$order      = strtoupper( sanitize_key( $attributes['order'] ?? 'DESC' ) );
-		$hide_empty = $attributes['hideEmpty'] ?? false;
-		$show_count = $attributes['showCount'] ?? true;
-		$columns    = absint( $attributes['columns'] ?? 2 );
-		$image_size = sanitize_key( $attributes['imageSize'] ?? 'woocommerce_thumbnail' );
+		$count         = absint( $attributes['count'] ?? 5 );
+		$orderby       = sanitize_key( $attributes['orderby'] ?? 'count' );
+		$order         = strtoupper( sanitize_key( $attributes['order'] ?? 'DESC' ) );
+		$hide_empty    = $attributes['hideEmpty'] ?? false;
+		$show_count    = $attributes['showCount'] ?? true;
+		$columns       = absint( $attributes['columns'] ?? 2 );
+		$image_size    = sanitize_key( $attributes['imageSize'] ?? 'woocommerce_thumbnail' );
 		$allowed_sizes = array( 'woocommerce_thumbnail', 'woocommerce_single', 'full', 'large', 'medium' );
 		if ( ! in_array( $image_size, $allowed_sizes, true ) ) {
 			$image_size = 'woocommerce_thumbnail';

--- a/includes/Frontend/ProductCategories.php
+++ b/includes/Frontend/ProductCategories.php
@@ -165,63 +165,63 @@ class ProductCategories {
 			'editor_script'   => 'frontblocks-product-categories-option',
 			'render_callback' => array( $this, 'render_product_categories_block' ),
 			'attributes'      => array(
-				'count'            => array(
+				'count'               => array(
 					'type'    => 'number',
 					'default' => 5,
 				),
-				'orderby'          => array(
+				'orderby'             => array(
 					'type'    => 'string',
 					'default' => 'count',
 				),
-				'order'            => array(
+				'order'               => array(
 					'type'    => 'string',
 					'default' => 'DESC',
 				),
-				'hideEmpty'        => array(
+				'hideEmpty'           => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),
-				'showCount'        => array(
+				'showCount'           => array(
 					'type'    => 'boolean',
 					'default' => true,
 				),
-				'className'        => array(
+				'className'           => array(
 					'type'    => 'string',
 					'default' => '',
 				),
-				'columns'          => array(
+				'columns'             => array(
 					'type'    => 'number',
 					'default' => 2,
 				),
-				'bgColor'          => array(
+				'bgColor'             => array(
 					'type'    => 'string',
 					'default' => 'rgba(255, 255, 255, 0.5)',
 				),
-				'borderColor'      => array(
+				'borderColor'         => array(
 					'type'    => 'string',
 					'default' => '#dddddd',
 				),
-				'borderWidth'      => array(
+				'borderWidth'         => array(
 					'type'    => 'number',
 					'default' => 1,
 				),
-				'borderRadius'     => array(
+				'borderRadius'        => array(
 					'type'    => 'number',
 					'default' => 20,
 				),
-				'textColor'        => array(
+				'textColor'           => array(
 					'type'    => 'string',
 					'default' => 'inherit',
 				),
-				'hoverBgColor'     => array(
+				'hoverBgColor'        => array(
 					'type'    => 'string',
 					'default' => 'rgba(255, 255, 255, 0.7)',
 				),
-				'hoverBorderColor' => array(
+				'hoverBorderColor'    => array(
 					'type'    => 'string',
 					'default' => '#555555',
 				),
-				'hoverTextColor'   => array(
+				'hoverTextColor'      => array(
 					'type'    => 'string',
 					'default' => 'inherit',
 				),
@@ -306,26 +306,26 @@ class ProductCategories {
 		$show_count = $attributes['showCount'] ?? true;
 		$columns    = absint( $attributes['columns'] ?? 2 );
 
-		$bg_color           = sanitize_text_field( $attributes['bgColor'] ?? 'rgba(255, 255, 255, 0.5)' );
-		$border_color       = sanitize_text_field( $attributes['borderColor'] ?? '#dddddd' );
-		$border_width       = absint( $attributes['borderWidth'] ?? 1 );
-		$border_radius      = absint( $attributes['borderRadius'] ?? 20 );
-		$text_color         = sanitize_text_field( $attributes['textColor'] ?? 'inherit' );
-		$hover_bg_color     = sanitize_text_field( $attributes['hoverBgColor'] ?? 'rgba(255, 255, 255, 0.7)' );
-		$hover_border_color = sanitize_text_field( $attributes['hoverBorderColor'] ?? '#555555' );
-		$hover_text_color   = sanitize_text_field( $attributes['hoverTextColor'] ?? 'inherit' );
-		$show_button           = ! empty( $attributes['showButton'] );
-		$button_text           = sanitize_text_field( $attributes['buttonText'] ?? '' );
-		$btn_bg_color          = sanitize_text_field( $attributes['btnBgColor'] ?? 'transparent' );
-		$btn_text_color        = sanitize_text_field( $attributes['btnTextColor'] ?? '' );
-		$btn_border_color      = sanitize_text_field( $attributes['btnBorderColor'] ?? '' );
-		$btn_border_width      = absint( $attributes['btnBorderWidth'] ?? 2 );
-		$btn_border_radius     = absint( $attributes['btnBorderRadius'] ?? 4 );
-		$btn_font_size         = absint( $attributes['btnFontSize'] ?? 14 );
-		$btn_padding_v         = absint( $attributes['btnPaddingV'] ?? 10 );
-		$btn_padding_h         = absint( $attributes['btnPaddingH'] ?? 20 );
-		$btn_hover_bg_color    = sanitize_text_field( $attributes['btnHoverBgColor'] ?? '' );
-		$btn_hover_text_color  = sanitize_text_field( $attributes['btnHoverTextColor'] ?? '' );
+		$bg_color               = sanitize_text_field( $attributes['bgColor'] ?? 'rgba(255, 255, 255, 0.5)' );
+		$border_color           = sanitize_text_field( $attributes['borderColor'] ?? '#dddddd' );
+		$border_width           = absint( $attributes['borderWidth'] ?? 1 );
+		$border_radius          = absint( $attributes['borderRadius'] ?? 20 );
+		$text_color             = sanitize_text_field( $attributes['textColor'] ?? 'inherit' );
+		$hover_bg_color         = sanitize_text_field( $attributes['hoverBgColor'] ?? 'rgba(255, 255, 255, 0.7)' );
+		$hover_border_color     = sanitize_text_field( $attributes['hoverBorderColor'] ?? '#555555' );
+		$hover_text_color       = sanitize_text_field( $attributes['hoverTextColor'] ?? 'inherit' );
+		$show_button            = ! empty( $attributes['showButton'] );
+		$button_text            = sanitize_text_field( $attributes['buttonText'] ?? '' );
+		$btn_bg_color           = sanitize_text_field( $attributes['btnBgColor'] ?? 'transparent' );
+		$btn_text_color         = sanitize_text_field( $attributes['btnTextColor'] ?? '' );
+		$btn_border_color       = sanitize_text_field( $attributes['btnBorderColor'] ?? '' );
+		$btn_border_width       = absint( $attributes['btnBorderWidth'] ?? 2 );
+		$btn_border_radius      = absint( $attributes['btnBorderRadius'] ?? 4 );
+		$btn_font_size          = absint( $attributes['btnFontSize'] ?? 14 );
+		$btn_padding_v          = absint( $attributes['btnPaddingV'] ?? 10 );
+		$btn_padding_h          = absint( $attributes['btnPaddingH'] ?? 20 );
+		$btn_hover_bg_color     = sanitize_text_field( $attributes['btnHoverBgColor'] ?? '' );
+		$btn_hover_text_color   = sanitize_text_field( $attributes['btnHoverTextColor'] ?? '' );
 		$btn_hover_border_color = sanitize_text_field( $attributes['btnHoverBorderColor'] ?? '' );
 
 		/**

--- a/includes/Plugin_Main.php
+++ b/includes/Plugin_Main.php
@@ -100,8 +100,10 @@ class Plugin_Main {
 		// Headline module (GenerateBlocks Headline enhancements).
 		new Frontend\Headline();
 
-		// Product Categories module (WooCommerce).
-		new Frontend\ProductCategories();
+		// Product Categories module (WooCommerce) — only when WooCommerce is active.
+		if ( class_exists( 'WooCommerce' ) ) {
+			new Frontend\ProductCategories();
+		}
 
 		// Counter module (GenerateBlocks Headline counter effect).
 		new Frontend\Counter();


### PR DESCRIPTION
## Summary

Enhances the Product Categories block with inline color picking and additional styling controls.

## Changes

- **JSX editor panel** (`frontblocks-product-categories-option.jsx`):
  - Added a `CompactColorPicker` component built with `ColorIndicator` + `Dropdown` + `Button` for a compact inline color selector that fits within the block sidebar.
  - Added `TextControl`, `ColorIndicator`, `Dropdown`, and `Button` to the import list.
  - Extended the block controls with new text and color options for category display customisation.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Fpost-new.php%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Ffrontblocks%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-163-fb1debe0d54842cc279220b5bb72b76b006fa10b.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22generateblocks%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->