### PR TITLE
Fluidtypography all themes

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1296,7 +1296,7 @@ class Settings {
 	 */
 	public function field_enable_fluid_typography() {
 		$options = get_option( 'frontblocks_settings', array() );
-		$enabled = (bool) ( $options[ $this->option_enable_fluid_typography ] ?? false );
+		$enabled = (bool) ( $options[ $this->option_enable_fluid_typography ] ?? true );
 		?>
 		<label class="frbl-toggle">
 			<input type="checkbox" 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1045,22 +1045,22 @@ class Settings {
 
 		// Short descriptions for each field.
 		$descriptions = array(
-			$this->option_enable_testimonials                     => __( 'Add a testimonials block to display customer reviews.', 'frontblocks' ),
-			$this->option_enable_reading_progress                 => __( 'Show a progress bar at the top of the page while reading posts.', 'frontblocks' ),
-			$this->option_enable_back_button                      => __( 'Add a floating back button for easy navigation.', 'frontblocks' ),
-			$this->option_enable_events                           => __( 'Register and display events using a CPT or blog posts.', 'frontblocks' ),
-			$this->option_enable_fluid_typography                 => __( 'Font sizes scale smoothly between mobile and desktop using CSS clamp().', 'frontblocks' ),
-			$this->option_enable_gutenberg                        => __( 'Use the block editor to write WooCommerce product descriptions.', 'frontblocks' ),
-			$this->option_enable_simple_prices_variable_products  => __( 'Show a simplified price range for variable products.', 'frontblocks' ),
-			$this->option_enable_after_add_to_cart                => __( 'Insert custom block content right after the Add to Cart button.', 'frontblocks' ),
-			$this->option_deactivate_short_description            => __( 'Remove the short description field from product pages.', 'frontblocks' ),
-			$this->option_move_content_to_short_description       => __( 'Move the main product content into the short description area.', 'frontblocks' ),
-			$this->option_disable_zoom_images                     => __( 'Remove the zoom effect on WooCommerce product images.', 'frontblocks' ),
-			$this->option_add_share_buttons                       => __( 'Add social share buttons to WooCommerce product pages.', 'frontblocks' ),
-			$this->option_deactivate_product_tabs                 => __( 'Remove the default description, reviews and attributes tabs.', 'frontblocks' ),
-			$this->option_horizontal_product_form                 => __( 'Display quantity and Add to Cart button side by side.', 'frontblocks' ),
-			$this->option_enable_fullpage_scroll                  => __( 'Enable full-page scroll navigation between sections.', 'frontblocks' ),
-			$this->option_enable_language_banner                  => __( 'Show a banner when the visitor language differs from the site language.', 'frontblocks' ),
+			$this->option_enable_testimonials          => __( 'Add a testimonials block to display customer reviews.', 'frontblocks' ),
+			$this->option_enable_reading_progress      => __( 'Show a progress bar at the top of the page while reading posts.', 'frontblocks' ),
+			$this->option_enable_back_button           => __( 'Add a floating back button for easy navigation.', 'frontblocks' ),
+			$this->option_enable_events                => __( 'Register and display events using a CPT or blog posts.', 'frontblocks' ),
+			$this->option_enable_fluid_typography      => __( 'Font sizes scale smoothly between mobile and desktop using CSS clamp().', 'frontblocks' ),
+			$this->option_enable_gutenberg             => __( 'Use the block editor to write WooCommerce product descriptions.', 'frontblocks' ),
+			$this->option_enable_simple_prices_variable_products => __( 'Show a simplified price range for variable products.', 'frontblocks' ),
+			$this->option_enable_after_add_to_cart     => __( 'Insert custom block content right after the Add to Cart button.', 'frontblocks' ),
+			$this->option_deactivate_short_description => __( 'Remove the short description field from product pages.', 'frontblocks' ),
+			$this->option_move_content_to_short_description => __( 'Move the main product content into the short description area.', 'frontblocks' ),
+			$this->option_disable_zoom_images          => __( 'Remove the zoom effect on WooCommerce product images.', 'frontblocks' ),
+			$this->option_add_share_buttons            => __( 'Add social share buttons to WooCommerce product pages.', 'frontblocks' ),
+			$this->option_deactivate_product_tabs      => __( 'Remove the default description, reviews and attributes tabs.', 'frontblocks' ),
+			$this->option_horizontal_product_form      => __( 'Display quantity and Add to Cart button side by side.', 'frontblocks' ),
+			$this->option_enable_fullpage_scroll       => __( 'Enable full-page scroll navigation between sections.', 'frontblocks' ),
+			$this->option_enable_language_banner       => __( 'Show a banner when the visitor language differs from the site language.', 'frontblocks' ),
 		);
 
 		$desc = $descriptions[ $field['id'] ] ?? '';

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1043,12 +1043,34 @@ class Settings {
 		// Get icon for this feature.
 		$icon = $this->get_feature_icon( $field['id'] );
 
+		// Short descriptions for each field.
+		$descriptions = array(
+			$this->option_enable_testimonials                     => __( 'Add a testimonials block to display customer reviews.', 'frontblocks' ),
+			$this->option_enable_reading_progress                 => __( 'Show a progress bar at the top of the page while reading posts.', 'frontblocks' ),
+			$this->option_enable_back_button                      => __( 'Add a floating back button for easy navigation.', 'frontblocks' ),
+			$this->option_enable_events                           => __( 'Register and display events using a CPT or blog posts.', 'frontblocks' ),
+			$this->option_enable_fluid_typography                 => __( 'Font sizes scale smoothly between mobile and desktop using CSS clamp().', 'frontblocks' ),
+			$this->option_enable_gutenberg                        => __( 'Use the block editor to write WooCommerce product descriptions.', 'frontblocks' ),
+			$this->option_enable_simple_prices_variable_products  => __( 'Show a simplified price range for variable products.', 'frontblocks' ),
+			$this->option_enable_after_add_to_cart                => __( 'Insert custom block content right after the Add to Cart button.', 'frontblocks' ),
+			$this->option_deactivate_short_description            => __( 'Remove the short description field from product pages.', 'frontblocks' ),
+			$this->option_move_content_to_short_description       => __( 'Move the main product content into the short description area.', 'frontblocks' ),
+			$this->option_disable_zoom_images                     => __( 'Remove the zoom effect on WooCommerce product images.', 'frontblocks' ),
+			$this->option_add_share_buttons                       => __( 'Add social share buttons to WooCommerce product pages.', 'frontblocks' ),
+			$this->option_deactivate_product_tabs                 => __( 'Remove the default description, reviews and attributes tabs.', 'frontblocks' ),
+			$this->option_horizontal_product_form                 => __( 'Display quantity and Add to Cart button side by side.', 'frontblocks' ),
+			$this->option_enable_fullpage_scroll                  => __( 'Enable full-page scroll navigation between sections.', 'frontblocks' ),
+			$this->option_enable_language_banner                  => __( 'Show a banner when the visitor language differs from the site language.', 'frontblocks' ),
+		);
+
+		$desc = $descriptions[ $field['id'] ] ?? '';
+
 		?>
 		<div class="frbl-feature-card <?php echo $needs_license ? 'frbl-feature-pro' : ''; ?>">
 			<?php if ( $is_pro_feature ) : ?>
 				<div class="frbl-pro-badge">PRO</div>
 			<?php endif; ?>
-			
+
 			<div class="frbl-feature-content">
 				<div class="frbl-feature-icon">
 					<?php echo $icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
@@ -1057,6 +1079,11 @@ class Settings {
 					<h3 class="frbl-feature-title">
 						<?php echo esc_html( $field['title'] ); ?>
 					</h3>
+					<?php if ( $desc ) : ?>
+						<p class="frbl-feature-description">
+							<?php echo esc_html( $desc ); ?>
+						</p>
+					<?php endif; ?>
 				</div>
 				<div class="frbl-feature-toggle">
 					<?php call_user_func( $field['callback'], $field['args'] ); ?>

--- a/includes/Frontend/FluidTypography.php
+++ b/includes/Frontend/FluidTypography.php
@@ -23,7 +23,6 @@ class FluidTypography {
 	 * Constructor.
 	 */
 	public function __construct() {
-		// Check if module is enabled.
 		if ( ! $this->is_enabled() ) {
 			return;
 		}
@@ -56,17 +55,14 @@ class FluidTypography {
 	 * @return void
 	 */
 	public function enqueue_fluid_typography() {
-		// Get GeneratePress dynamic CSS output.
-		$dynamic_css = get_option( 'generate_dynamic_css_output', '' );
+		$source_css = $this->get_source_css();
 
-		if ( empty( $dynamic_css ) ) {
+		if ( empty( $source_css ) ) {
 			return;
 		}
 
-		// Generate fluid typography CSS from dynamic CSS.
-		$fluid_css = $this->convert_to_fluid_typography( $dynamic_css );
+		$fluid_css = $this->convert_to_fluid_typography( $source_css );
 
-		// DEBUG: Show generated CSS as HTML comment for admins.
 		if ( current_user_can( 'manage_options' ) && isset( $_GET['frbl_debug'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			add_action(
 				'wp_head',
@@ -76,33 +72,87 @@ class FluidTypography {
 			);
 		}
 
-		if ( ! empty( $fluid_css ) ) {
-			wp_add_inline_style( 'generate-style', $fluid_css );
+		if ( empty( $fluid_css ) ) {
+			return;
 		}
+
+		$style_handle = $this->get_style_handle();
+		wp_add_inline_style( $style_handle, $fluid_css );
 	}
 
 	/**
-	 * Convert GeneratePress static CSS to fluid typography.
+	 * Get CSS source depending on active theme.
+	 * Priority: GeneratePress → theme.json global stylesheet → theme stylesheet.
 	 *
-	 * @param string $css Dynamic CSS from GeneratePress.
+	 * @return string
+	 */
+	private function get_source_css(): string {
+		// 1. GeneratePress — use its pre-compiled dynamic CSS cache.
+		if ( function_exists( 'generate_get_default_color_palettes' ) ) {
+			$gp_css = get_option( 'generate_dynamic_css_output', '' );
+			if ( ! empty( $gp_css ) ) {
+				return $gp_css;
+			}
+		}
+
+		// 2. Block/FSE themes — compile from theme.json via WP core.
+		if ( function_exists( 'wp_get_global_stylesheet' ) ) {
+			$global_css = wp_get_global_stylesheet();
+			if ( ! empty( $global_css ) ) {
+				return $global_css;
+			}
+		}
+
+		// 3. Classic themes — read the theme's style.css.
+		$stylesheet = get_stylesheet_directory() . '/style.css';
+		if ( file_exists( $stylesheet ) ) {
+			$css = file_get_contents( $stylesheet ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			if ( ! empty( $css ) ) {
+				return $css;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Return the registered style handle to attach the fluid CSS to.
+	 * Falls back to 'wp-block-library' (always enqueued) if the theme handle isn't found.
+	 *
+	 * @return string
+	 */
+	private function get_style_handle(): string {
+		// GeneratePress.
+		if ( wp_style_is( 'generate-style', 'enqueued' ) ) {
+			return 'generate-style';
+		}
+
+		// Common theme handles.
+		$candidates = array( 'parent-style', 'child-style', 'theme-style', 'main-style', get_stylesheet() );
+		foreach ( $candidates as $handle ) {
+			if ( wp_style_is( $handle, 'enqueued' ) ) {
+				return $handle;
+			}
+		}
+
+		// Universal fallback — always present when blocks are used.
+		return 'wp-block-library';
+	}
+
+	/**
+	 * Convert source CSS to fluid typography using clamp().
+	 *
+	 * @param string $css Source CSS.
 	 * @return string Fluid typography CSS.
 	 */
 	private function convert_to_fluid_typography( $css ) {
 		$fluid_css = '';
+		$selectors = array( 'body', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' );
 
-		// Typography selectors to process - starting with simple ones that definitely work.
-		$selectors = array(
-			'body',  // Body text (paragraphs inherit from this).
-			'h1',    // Heading 1.
-			'h2',    // Heading 2.
-			'h3',    // Heading 3.
-			'h4',    // Heading 4.
-			'h5',    // Heading 5.
-			'h6',    // Heading 6.
-		);
+		$is_generateblocks = class_exists( 'GenerateBlocks' );
 
 		foreach ( $selectors as $selector ) {
-			$fluid_rule = $this->extract_and_convert_selector( $css, $selector );
+			$fluid_rule = $this->extract_and_convert_selector( $css, $selector, $is_generateblocks );
 
 			if ( ! empty( $fluid_rule ) ) {
 				$fluid_css .= $fluid_rule . "\n";
@@ -115,22 +165,21 @@ class FluidTypography {
 	/**
 	 * Extract font sizes from CSS and convert to fluid typography.
 	 *
-	 * @param string $css CSS content.
-	 * @param string $selector CSS selector (e.g., 'h1').
+	 * @param string $css                Source CSS.
+	 * @param string $selector           CSS selector (e.g. 'h1').
+	 * @param bool   $is_generateblocks  Whether GenerateBlocks is active.
 	 * @return string Fluid CSS rule or empty string.
 	 */
-	private function extract_and_convert_selector( $css, $selector ) {
+	private function extract_and_convert_selector( $css, $selector, $is_generateblocks = false ) {
 		$sizes = array(
 			'desktop' => null,
 			'tablet'  => null,
 			'mobile'  => null,
 		);
 
-		// Use different regex patterns depending on the selector.
-		// Body is in a multiple selector (body, button, input...), headings are standalone.
 		$is_multiple_selector = ( 'body' === $selector );
 
-		// Extract base/desktop font-size.
+		// Desktop font-size.
 		if ( $is_multiple_selector ) {
 			$pattern = '/(?:^|,|\})\s*[^{]*\b' . preg_quote( $selector, '/' ) . '\b[^{]*\{[^}]*font-size:\s*([0-9.]+)(px|rem|em)/i';
 		} else {
@@ -144,9 +193,8 @@ class FluidTypography {
 			);
 		}
 
-		// Extract tablet font-size from @media (max-width: 1024px).
+		// Tablet font-size — @media (max-width: 1024px).
 		if ( $is_multiple_selector ) {
-			// Pattern for body in media query.
 			$pattern_tablet = '/@media[^{]*max-width:\s*1024px[^{]*\{[^@]*\b' . preg_quote( $selector, '/' ) . '\b[^{]*\{[^}]*font-size:\s*([0-9.]+)(px|rem|em)/is';
 		} else {
 			$pattern_tablet = '/@media[^{]*max-width:\s*1024px[^{]*\{[^}]*' . preg_quote( $selector, '/' ) . '\s*\{[^}]*font-size:\s*([0-9.]+)(px|rem|em)/is';
@@ -159,9 +207,8 @@ class FluidTypography {
 			);
 		}
 
-		// Extract mobile font-size from @media (max-width: 768px).
+		// Mobile font-size — @media (max-width: 768px).
 		if ( $is_multiple_selector ) {
-			// Pattern for body in media query.
 			$pattern_mobile = '/@media[^{]*max-width:\s*768px[^{]*\{[^@]*\b' . preg_quote( $selector, '/' ) . '\b[^{]*\{[^}]*font-size:\s*([0-9.]+)(px|rem|em)/is';
 		} else {
 			$pattern_mobile = '/@media[^{]*max-width:\s*768px[^{]*\{[^}]*' . preg_quote( $selector, '/' ) . '\s*\{[^}]*font-size:\s*([0-9.]+)(px|rem|em)/is';
@@ -174,12 +221,10 @@ class FluidTypography {
 			);
 		}
 
-		// If we don't have enough data, skip.
 		if ( ! $sizes['desktop'] || ! $sizes['mobile'] ) {
 			return '';
 		}
 
-		// Ensure all units are the same.
 		if ( $sizes['desktop']['unit'] !== $sizes['mobile']['unit'] ) {
 			return '';
 		}
@@ -188,18 +233,14 @@ class FluidTypography {
 		$max_size = $sizes['desktop']['value'];
 		$unit     = $sizes['desktop']['unit'];
 
-		// Skip if same values.
 		if ( $min_size === $max_size ) {
 			return '';
 		}
 
-		// Generate fluid typography with clamp().
-		// Viewport range: 320px (mobile) to 1440px (desktop).
 		$viewport_start = 320;
 		$viewport_end   = 1440;
 		$viewport_diff  = $viewport_end - $viewport_start;
 
-		// Build clamp() formula.
 		$fluid_calc = sprintf(
 			'calc(%1$s%2$s + (%3$s - %1$s) * ((100vw - %4$spx) / %5$s))',
 			$min_size,
@@ -217,14 +258,17 @@ class FluidTypography {
 			$max_size
 		);
 
-		// Generate CSS rule with appropriate specificity.
 		if ( in_array( $selector, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ), true ) ) {
-			// For headings, use high specificity to ensure they always win over body classes.
-			$rule = sprintf( "body %s,\nbody %s.gb-headline {\n\tfont-size: %s !important;\n}", $selector, $selector, $clamp_rule );
+			$rule = sprintf( "body %s {\n\tfont-size: %s !important;\n}", $selector, $clamp_rule );
+
+			// Add GenerateBlocks-specific selector only when GB is active.
+			if ( $is_generateblocks ) {
+				$rule .= sprintf( "\nbody %s.gb-headline {\n\tfont-size: %s !important;\n}", $selector, $clamp_rule );
+			}
 		} else {
-			// For body, apply to body and paragraphs with GB classes.
 			$rule = sprintf( "%s {\n\tfont-size: %s !important;\n}", $selector, $clamp_rule );
-			if ( 'body' === $selector ) {
+
+			if ( 'body' === $selector && $is_generateblocks ) {
 				$rule .= sprintf( "\np.gb-headline-text {\n\tfont-size: %s !important;\n}", $clamp_rule );
 			}
 		}

--- a/includes/Frontend/FluidTypography.php
+++ b/includes/Frontend/FluidTypography.php
@@ -37,7 +37,7 @@ class FluidTypography {
 	 */
 	private function is_enabled() {
 		$options = get_option( 'frontblocks_settings', array() );
-		return ! empty( $options['enable_fluid_typography'] );
+		return (bool) ( $options['enable_fluid_typography'] ?? true );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Extends the Fluid Typography module to work with all themes, not just GeneratePress. Also adds a PRO features upsell section to the Settings page.

## Changes

- **PHP — Fluid Typography** (`FluidTypography.php`):
  - Added `get_source_css()` with priority order: GeneratePress dynamic CSS → `wp_get_global_stylesheet()` for block/FSE themes → theme `style.css` for classic themes.
  - Added `get_style_handle()` to locate the correct enqueued style handle to attach the generated fluid CSS to.
  - Changed `is_enabled()` default from `false` to `true`.
  - Added `$is_generateblocks` flag passed to `extract_and_convert_selector()` to conditionally include `.gb-headline` and `p.gb-headline-text` selectors.
- **PHP — Settings** (`Settings.php`):
  - Added `$descriptions` array with short descriptions for all feature toggle fields.
  - Changed fluid typography default to `true`.
  - Refactored `section_active_blocks_callback()` to use the `frbl_active_blocks` filter.
  - Added `get_default_pro_blocks()` returning 13 PRO feature definitions.
  - Added `render_pro_section()` for the upsell section.
  - Added a PRO CTA button above the Optional Features section.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Fpost-new.php%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Ffrontblocks%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-179-6a4b8dd42e3f80736f76403d209d34f92a25a20d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22generateblocks%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->