### PR TITLE
Sticky column native

### DIFF
--- a/assets/sticky-column/frontblocks-sticky-column-option.js
+++ b/assets/sticky-column/frontblocks-sticky-column-option.js
@@ -13,12 +13,13 @@
     SelectControl = _wp$components.SelectControl;
   var addFilter = wp.hooks.addFilter;
   var select = wp.data.select;
+  var SUPPORTED_BLOCKS = ['generateblocks/grid', 'core/columns'];
 
-  // Add sticky column controls to the GenerateBlocks Grid block
+  // Add sticky column controls to supported grid/columns blocks
   addFilter('editor.BlockEdit', 'frontblocks/sticky-column-controls', function (BlockEdit) {
     return function (props) {
-      // Only add controls to GenerateBlocks Grid block
-      if (props.name !== 'generateblocks/grid') {
+      // Only add controls to supported blocks
+      if (!SUPPORTED_BLOCKS.includes(props.name)) {
         return el(BlockEdit, props);
       }
       var attributes = props.attributes,

--- a/assets/sticky-column/frontblocks-sticky-column-option.jsx
+++ b/assets/sticky-column/frontblocks-sticky-column-option.jsx
@@ -8,14 +8,16 @@
     const { addFilter } = wp.hooks;
     const { select } = wp.data;
 
-    // Add sticky column controls to the GenerateBlocks Grid block
+    const SUPPORTED_BLOCKS = ['generateblocks/grid', 'core/columns'];
+
+    // Add sticky column controls to supported grid/columns blocks
     addFilter(
         'editor.BlockEdit',
         'frontblocks/sticky-column-controls',
         function(BlockEdit) {
             return function(props) {
-                // Only add controls to GenerateBlocks Grid block
-                if (props.name !== 'generateblocks/grid') {
+                // Only add controls to supported blocks
+                if (!SUPPORTED_BLOCKS.includes(props.name)) {
                     return el(BlockEdit, props);
                 }
 

--- a/assets/sticky-column/frontblocks-sticky-column.css
+++ b/assets/sticky-column/frontblocks-sticky-column.css
@@ -14,6 +14,18 @@
     z-index: 100;
     background: inherit;
 }
+/* Native core/columns support */
+.frontblocks-sticky-wrapper .wp-block-column {
+    transition: position 0.3s ease;
+}
+
+.frontblocks-sticky-wrapper .wp-block-column.sticky-active {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: inherit;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .frontblocks-sticky-wrapper .gb-grid-column.sticky-active .gb-container {
@@ -21,5 +33,11 @@
         top: auto !important;
         z-index: auto;
         box-shadow: none;
+    }
+
+    .frontblocks-sticky-wrapper .wp-block-column.sticky-active {
+        position: relative;
+        top: auto !important;
+        z-index: auto;
     }
 } 

--- a/assets/sticky-column/frontblocks-sticky-column.css
+++ b/assets/sticky-column/frontblocks-sticky-column.css
@@ -3,41 +3,12 @@
     position: relative;
 }
 
-.frontblocks-sticky-wrapper .gb-grid-column {
-    transition: position 0.3s ease;
-}
-
-/* Apply sticky positioning to the column wrapper, not the container */
-.frontblocks-sticky-wrapper .gb-grid-column.sticky-active .gb-container {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    background: inherit;
-}
-/* Native core/columns support */
-.frontblocks-sticky-wrapper .wp-block-column {
-    transition: position 0.3s ease;
-}
-
-.frontblocks-sticky-wrapper .wp-block-column.sticky-active {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    background: inherit;
-}
-
-/* Responsive adjustments */
+/* Disable sticky on mobile — JS applies position:sticky via inline styles */
 @media (max-width: 768px) {
-    .frontblocks-sticky-wrapper .gb-grid-column.sticky-active .gb-container {
-        position: relative;
+    .frontblocks-sticky-wrapper .gb-grid-column .gb-container,
+    .frontblocks-sticky-wrapper .wp-block-column {
+        position: relative !important;
         top: auto !important;
-        z-index: auto;
-        box-shadow: none;
+        z-index: auto !important;
     }
-
-    .frontblocks-sticky-wrapper .wp-block-column.sticky-active {
-        position: relative;
-        top: auto !important;
-        z-index: auto;
-    }
-} 
+}

--- a/assets/sticky-column/frontblocks-sticky-column.js
+++ b/assets/sticky-column/frontblocks-sticky-column.js
@@ -1,71 +1,56 @@
 (function() {
     'use strict';
 
-    // Initialize sticky columns when DOM is ready
     document.addEventListener('DOMContentLoaded', function() {
         initStickyColumns();
     });
 
-    // Also initialize on window load for dynamic content
     window.addEventListener('load', function() {
         initStickyColumns();
     });
 
     function initStickyColumns() {
         const stickyWrappers = document.querySelectorAll('.frontblocks-sticky-wrapper[data-sticky-enabled="true"]');
-        
+
         stickyWrappers.forEach(function(wrapper) {
-            const stickyOffset = parseInt(wrapper.getAttribute('data-sticky-offset')) || 0;
+            const stickyOffset    = parseInt(wrapper.getAttribute('data-sticky-offset')) || 0;
             const stickyColumnIndex = parseInt(wrapper.getAttribute('data-sticky-column-index')) || 0;
-            
-            const columns = wrapper.querySelectorAll('.gb-grid-column, .wp-block-column');
-            
-            if (columns.length > stickyColumnIndex) {
-                const stickyColumn = columns[stickyColumnIndex];
-                setupStickyColumn(stickyColumn, stickyOffset);
+
+            // Only direct children to avoid matching nested blocks.
+            const columns = wrapper.querySelectorAll(':scope > .gb-grid-column, :scope > .wp-block-column');
+
+            if (columns.length <= stickyColumnIndex) {
+                return;
+            }
+
+            const column = columns[stickyColumnIndex];
+
+            // For GenerateBlocks, apply sticky to the inner .gb-container (it's not the flex item).
+            // For native wp-block-column, create an inner wrapper — applying sticky directly to
+            // a flex item is unreliable across browsers; sticky works best on a descendant of the flex item.
+            let stickyTarget = column.querySelector('.gb-container');
+
+            if (!stickyTarget) {
+                stickyTarget = document.createElement('div');
+                stickyTarget.className = 'frontblocks-sticky-inner';
+                while (column.firstChild) {
+                    stickyTarget.appendChild(column.firstChild);
+                }
+                column.appendChild(stickyTarget);
+            }
+
+            // Apply sticky via inline styles — avoids specificity wars with WP-generated .wp-container-* rules.
+            stickyTarget.style.position = 'sticky';
+            stickyTarget.style.top      = stickyOffset + 'px';
+            stickyTarget.style.zIndex   = '100';
+
+            // flex-start needed so the column has natural height; without it position:sticky has no room to scroll.
+            if (wrapper.classList.contains('wp-block-columns')) {
+                wrapper.style.alignItems = 'flex-start';
             }
         });
     }
 
-    function setupStickyColumn(column, offset) {
-        let isSticky = false;
-        // GenerateBlocks uses an inner .gb-container; native columns use the column itself.
-        const stickyTarget = column.querySelector('.gb-container') || column;
-
-        function checkStickyPosition() {
-            const wrapper = column.closest('.frontblocks-sticky-wrapper');
-            const wrapperRect = wrapper.getBoundingClientRect();
-
-            // Check if the column should be sticky
-            if (wrapperRect.top <= offset && !isSticky) {
-                column.classList.add('sticky-active');
-                stickyTarget.style.top = offset + 'px';
-                isSticky = true;
-            } else if (wrapperRect.top > offset && isSticky) {
-                column.classList.remove('sticky-active');
-                stickyTarget.style.top = '';
-                isSticky = false;
-            }
-
-            // Check if we've scrolled past the wrapper
-            if (wrapperRect.bottom <= offset && isSticky) {
-                column.classList.remove('sticky-active');
-                stickyTarget.style.top = '';
-                isSticky = false;
-            }
-        }
-        
-        // Add scroll event listener
-        window.addEventListener('scroll', checkStickyPosition, { passive: true });
-        
-        // Initial check
-        checkStickyPosition();
-        
-        // Check on resize
-        window.addEventListener('resize', checkStickyPosition, { passive: true });
-    }
-
-    // Re-initialize when new content is loaded (for AJAX content)
     if (typeof wp !== 'undefined' && wp.hooks) {
         wp.hooks.addAction('frontblocks/sticky-columns-reinit', 'frontblocks/sticky-columns', initStickyColumns);
     }

--- a/assets/sticky-column/frontblocks-sticky-column.js
+++ b/assets/sticky-column/frontblocks-sticky-column.js
@@ -18,7 +18,7 @@
             const stickyOffset = parseInt(wrapper.getAttribute('data-sticky-offset')) || 0;
             const stickyColumnIndex = parseInt(wrapper.getAttribute('data-sticky-column-index')) || 0;
             
-            const columns = wrapper.querySelectorAll('.gb-grid-column');
+            const columns = wrapper.querySelectorAll('.gb-grid-column, .wp-block-column');
             
             if (columns.length > stickyColumnIndex) {
                 const stickyColumn = columns[stickyColumnIndex];
@@ -29,39 +29,28 @@
 
     function setupStickyColumn(column, offset) {
         let isSticky = false;
-        
+        // GenerateBlocks uses an inner .gb-container; native columns use the column itself.
+        const stickyTarget = column.querySelector('.gb-container') || column;
+
         function checkStickyPosition() {
-            const rect = column.getBoundingClientRect();
             const wrapper = column.closest('.frontblocks-sticky-wrapper');
             const wrapperRect = wrapper.getBoundingClientRect();
-            
+
             // Check if the column should be sticky
             if (wrapperRect.top <= offset && !isSticky) {
                 column.classList.add('sticky-active');
-                // Apply offset to the gb-container within the sticky column
-                const container = column.querySelector('.gb-container');
-                if (container) {
-                    container.style.top = offset + 'px';
-                }
+                stickyTarget.style.top = offset + 'px';
                 isSticky = true;
             } else if (wrapperRect.top > offset && isSticky) {
                 column.classList.remove('sticky-active');
-                // Remove offset from the gb-container
-                const container = column.querySelector('.gb-container');
-                if (container) {
-                    container.style.top = '';
-                }
+                stickyTarget.style.top = '';
                 isSticky = false;
             }
-            
+
             // Check if we've scrolled past the wrapper
             if (wrapperRect.bottom <= offset && isSticky) {
                 column.classList.remove('sticky-active');
-                // Remove offset from the gb-container
-                const container = column.querySelector('.gb-container');
-                if (container) {
-                    container.style.top = '';
-                }
+                stickyTarget.style.top = '';
                 isSticky = false;
             }
         }

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -893,7 +893,7 @@ class Settings {
 			UI::show_info_card( 'animations', __( 'Animations', 'frontblocks' ), __( 'Add animations to any block using Animate.css', 'frontblocks' ) );
 			UI::show_info_card( 'carousel', __( 'Carousel/Slider', 'frontblocks' ), __( 'Transform any Grid block into a carousel or slider', 'frontblocks' ) );
 			UI::show_info_card( 'gallery', __( 'Native Gallery', 'frontblocks' ), __( 'Enhanced gallery block with carousel and masonry options', 'frontblocks' ) );
-			UI::show_info_card( 'sticky', __( 'Sticky Columns', 'frontblocks' ), __( 'Make Grid blocks sticky when scrolling', 'frontblocks' ) );
+			UI::show_info_card( 'sticky', __( 'Sticky Columns', 'frontblocks' ), __( 'Make Grid or Columns blocks sticky when scrolling', 'frontblocks' ) );
 			UI::show_info_card( 'insert_post', __( 'Insert Post Block', 'frontblocks' ), __( 'Display content from other posts, pages or custom post types', 'frontblocks' ) );
 			UI::show_info_card( 'counter', __( 'Counter Block', 'frontblocks' ), __( 'Display animated counters with start and end values', 'frontblocks' ) );
 			UI::show_info_card( 'reading_time', __( 'Reading Time Block', 'frontblocks' ), __( 'Show estimated reading time for posts', 'frontblocks' ) );

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -893,7 +893,7 @@ class Settings {
 			UI::show_info_card( 'animations', __( 'Animations', 'frontblocks' ), __( 'Add animations to any block using Animate.css', 'frontblocks' ) );
 			UI::show_info_card( 'carousel', __( 'Carousel/Slider', 'frontblocks' ), __( 'Transform any Grid block into a carousel or slider', 'frontblocks' ) );
 			UI::show_info_card( 'gallery', __( 'Native Gallery', 'frontblocks' ), __( 'Enhanced gallery block with carousel and masonry options', 'frontblocks' ) );
-			UI::show_info_card( 'sticky', __( 'Sticky Columns', 'frontblocks' ), __( 'Make Grid or Columns blocks sticky when scrolling', 'frontblocks' ) );
+			UI::show_info_card( 'sticky', __( 'Sticky Columns', 'frontblocks' ), __( 'Keep a column fixed while scrolling. Supports GenerateBlocks Grid and native Columns blocks.', 'frontblocks' ) );
 			UI::show_info_card( 'insert_post', __( 'Insert Post Block', 'frontblocks' ), __( 'Display content from other posts, pages or custom post types', 'frontblocks' ) );
 			UI::show_info_card( 'counter', __( 'Counter Block', 'frontblocks' ), __( 'Display animated counters with start and end values', 'frontblocks' ) );
 			UI::show_info_card( 'reading_time', __( 'Reading Time Block', 'frontblocks' ), __( 'Show estimated reading time for posts', 'frontblocks' ) );

--- a/includes/Frontend/StickyColumn.php
+++ b/includes/Frontend/StickyColumn.php
@@ -35,6 +35,7 @@ class StickyColumn {
 		add_action( 'init', array( $this, 'register_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_filter( 'render_block_generateblocks/grid', array( $this, 'add_sticky_attributes_to_grid_block' ), 10, 2 );
+		add_filter( 'render_block_core/columns', array( $this, 'add_sticky_attributes_to_columns_block' ), 10, 2 );
 		add_action( 'init', array( $this, 'register_custom_attributes' ), 5 );
 	}
 
@@ -89,31 +90,54 @@ class StickyColumn {
 	 * @return string
 	 */
 	public function add_sticky_attributes_to_grid_block( $block_content, $block ) {
+		return $this->add_sticky_attributes( $block_content, $block, 'gb-grid-wrapper' );
+	}
+
+	/**
+	 * Add sticky attributes to native core/columns block.
+	 *
+	 * @param string $block_content Block content.
+	 * @param array  $block Block attributes.
+	 * @return string
+	 */
+	public function add_sticky_attributes_to_columns_block( $block_content, $block ) {
+		return $this->add_sticky_attributes( $block_content, $block, 'wp-block-columns' );
+	}
+
+	/**
+	 * Generic method to inject sticky wrapper class and data attributes.
+	 *
+	 * @param string $block_content Block content.
+	 * @param array  $block Block data.
+	 * @param string $wrapper_class CSS class that identifies the wrapper div.
+	 * @return string
+	 */
+	private function add_sticky_attributes( $block_content, $block, $wrapper_class ) {
 		$attrs               = $block['attrs'] ?? array();
 		$sticky_enabled      = isset( $attrs['frblStickyEnabled'] ) ? (bool) $attrs['frblStickyEnabled'] : false;
 		$sticky_offset       = isset( $attrs['frblStickyOffset'] ) ? (int) $attrs['frblStickyOffset'] : 0;
 		$sticky_column_index = isset( $attrs['frblStickyColumnIndex'] ) ? (int) $attrs['frblStickyColumnIndex'] : 0;
 
-		// Add sticky attributes to the wrapper div if sticky is enabled.
-		if ( $sticky_enabled ) {
-			$block_content = preg_replace(
-				'/<div([^>]*)class="([^"]*gb-grid-wrapper[^"]*)"([^>]*)>/',
-				'<div$1class="$2 frontblocks-sticky-wrapper"$3' .
-					' data-sticky-enabled="' . esc_attr( $sticky_enabled ? 'true' : 'false' ) . '"' .
-					' data-sticky-offset="' . esc_attr( $sticky_offset ) . '"' .
-					' data-sticky-column-index="' . esc_attr( $sticky_column_index ) . '"' .
-					'>',
-				$block_content,
-				1 // Only replace the first occurrence.
-			);
+		if ( ! $sticky_enabled ) {
+			return $block_content;
+		}
 
-			// Enqueue frontend assets only when a sticky column block is detected.
-			if ( ! wp_style_is( 'frontblocks-sticky-column', 'enqueued' ) ) {
-				wp_enqueue_style( 'frontblocks-sticky-column' );
-			}
-			if ( ! wp_script_is( 'frontblocks-sticky-column-custom', 'enqueued' ) ) {
-				wp_enqueue_script( 'frontblocks-sticky-column-custom' );
-			}
+		$block_content = preg_replace(
+			'/<div([^>]*)class="([^"]*' . preg_quote( $wrapper_class, '/' ) . '[^"]*)"([^>]*)>/',
+			'<div$1class="$2 frontblocks-sticky-wrapper"$3' .
+				' data-sticky-enabled="true"' .
+				' data-sticky-offset="' . esc_attr( $sticky_offset ) . '"' .
+				' data-sticky-column-index="' . esc_attr( $sticky_column_index ) . '"' .
+				'>',
+			$block_content,
+			1
+		);
+
+		if ( ! wp_style_is( 'frontblocks-sticky-column', 'enqueued' ) ) {
+			wp_enqueue_style( 'frontblocks-sticky-column' );
+		}
+		if ( ! wp_script_is( 'frontblocks-sticky-column-custom', 'enqueued' ) ) {
+			wp_enqueue_script( 'frontblocks-sticky-column-custom' );
 		}
 
 		return $block_content;
@@ -132,6 +156,9 @@ class StickyColumn {
 			9,
 			2
 		);
+
+		// Register attributes for native core/columns block.
+		add_filter( 'register_block_type_args', array( $this, 'register_sticky_attributes_for_columns_block' ), 10, 2 );
 
 		// Register attributes from frontend side as well.
 		add_action(
@@ -169,6 +196,34 @@ class StickyColumn {
 	}
 
 	/**
+	 * Register sticky attributes for native core/columns block via register_block_type_args.
+	 *
+	 * @param array  $args       Block type arguments.
+	 * @param string $block_type Block type name.
+	 * @return array
+	 */
+	public function register_sticky_attributes_for_columns_block( $args, $block_type ) {
+		if ( 'core/columns' !== $block_type ) {
+			return $args;
+		}
+
+		$args['attributes']['frblStickyEnabled']     = array(
+			'type'    => 'boolean',
+			'default' => false,
+		);
+		$args['attributes']['frblStickyOffset']      = array(
+			'type'    => 'number',
+			'default' => 0,
+		);
+		$args['attributes']['frblStickyColumnIndex'] = array(
+			'type'    => 'number',
+			'default' => 0,
+		);
+
+		return $args;
+	}
+
+	/**
 	 * Add inline script for block attributes.
 	 *
 	 * @return void
@@ -181,7 +236,7 @@ class StickyColumn {
 				'blocks.registerBlockType',
 				'frontblocks/sticky-attributes',
 				function( settings, name ) {
-					if ( name !== 'generateblocks/grid' ) {
+					if ( name !== 'generateblocks/grid' && name !== 'core/columns' ) {
 						return settings;
 					}
 


### PR DESCRIPTION
## Summary

Extends the Sticky Column feature to the native `core/columns` block, previously only available for `generateblocks/grid`.

## Changes

- **JSX editor panel** (`frontblocks-sticky-column-option.jsx`): Added `core/columns` to `SUPPORTED_BLOCKS` array; block name checks updated throughout to use the array.
- **JS frontend** (`frontblocks-sticky-column.js`): Rewrote the sticky implementation from scroll-event-based class toggling to applying `position: sticky` directly via inline styles. Uses `:scope > .gb-grid-column, :scope > .wp-block-column` selector to target child columns. For native `wp-block-columns`, creates a `.frontblocks-sticky-inner` wrapper div around all children and sets `wrapper.style.alignItems = 'flex-start'` to prevent stretch alignment from breaking sticky behaviour.
- **CSS** (`frontblocks-sticky-column.css`): Removed class-based sticky rules. Simplified to a single mobile override using `position: relative !important` for both `.gb-grid-column .gb-container` and `.wp-block-column`.
- **PHP render** (`StickyColumn.php`): Added `add_sticky_attributes_to_columns_block()` delegating to the shared `add_sticky_attributes()` helper; added `register_sticky_attributes_for_columns_block()` via `register_block_type_args` to register `frblStickyEnabled`, `frblStickyOffset`, and `frblStickyColumnIndex` on `core/columns`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Fpost-new.php%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Ffrontblocks%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-180-f4a7bbf3c731e1577cbe511dd43c9155174f08f0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22generateblocks%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->