### PR TITLE
Add marquee in native paragraph and headline blocks

### DIFF
--- a/assets/headline/frontblocks-headline-option.jsx
+++ b/assets/headline/frontblocks-headline-option.jsx
@@ -1,13 +1,15 @@
 const { createHigherOrderComponent } = wp.compose;
 const { Fragment } = wp.element;
-const { InspectorControls } = wp.blockEditor; 
+const { InspectorControls } = wp.blockEditor;
 const { PanelBody, SelectControl, ToggleControl } = wp.components;
 const { __, sprintf } = wp.i18n;
 
-const LINE_CLASS_PREFIX = 'gb-line-effect-'; 
+const LINE_CLASS_PREFIX = 'gb-line-effect-';
 const MARQUEE_CLASS = 'gb-marquee-infinite-scroll';
 const MARQUEE_SPEED_ATTR = 'frblMarqueeSpeed';
-const BLOCK_NAME = 'generateblocks/text';
+const GB_BLOCK = 'generateblocks/text';
+const NATIVE_BLOCKS = [ 'core/paragraph', 'core/heading' ];
+const ALL_MARQUEE_BLOCKS = [ GB_BLOCK, ...NATIVE_BLOCKS ];
 
 // Marquee speed presets
 const MARQUEE_SPEEDS = {
@@ -16,26 +18,26 @@ const MARQUEE_SPEEDS = {
     slow: 40     // 40 seconds - slow
 };
 
-// Register marquee speed attribute
+// Register marquee speed attribute for all supported blocks
 wp.hooks.addFilter(
     'blocks.registerBlockType',
     'frontblocks/add-marquee-attribute',
     ( settings, name ) => {
-        if ( name === BLOCK_NAME ) {
+        if ( ALL_MARQUEE_BLOCKS.includes( name ) ) {
             settings.attributes = Object.assign( settings.attributes || {}, {
                 [MARQUEE_SPEED_ATTR]: {
                     type: 'string',
-                    default: 'medium',
+                    default: '',
                 },
             } );
         }
         return settings;
     }
-); 
+);
 
 const withHeadlineLineControl = createHigherOrderComponent( ( BlockEdit ) => {
    return ( props ) => {
-      if ( props.name !== BLOCK_NAME ) {
+      if ( ! ALL_MARQUEE_BLOCKS.includes( props.name ) ) {
          return <BlockEdit { ...props } />;
       }
 
@@ -43,7 +45,8 @@ const withHeadlineLineControl = createHigherOrderComponent( ( BlockEdit ) => {
       const existingClasses = attributes.className || '';
       const htmlAttributes = attributes.htmlAttributes || {};
       const marqueeSpeed = attributes[MARQUEE_SPEED_ATTR] || 'medium';
-        
+      const isGBBlock = props.name === GB_BLOCK;
+
       const cleanExistingLineClasses = ( classes ) => {
          return classes
             .split(' ')
@@ -63,18 +66,16 @@ const withHeadlineLineControl = createHigherOrderComponent( ( BlockEdit ) => {
       };
 
       let currentLineStyle = 'none';
-      if (existingClasses.includes(LINE_CLASS_PREFIX + 'vertical')) {
-         currentLineStyle = 'vertical';
-      } else if (existingClasses.includes(LINE_CLASS_PREFIX + 'horizontal')) {
-         currentLineStyle = 'horizontal';
+      if ( isGBBlock ) {
+         if ( existingClasses.includes( LINE_CLASS_PREFIX + 'vertical' ) ) {
+            currentLineStyle = 'vertical';
+         } else if ( existingClasses.includes( LINE_CLASS_PREFIX + 'horizontal' ) ) {
+            currentLineStyle = 'horizontal';
+         }
       }
 
       const isMarqueeEnabled = existingClasses.includes(MARQUEE_CLASS);
 
-
-      /**
-      * Maneja el cambio del SelectControl y actualiza las clases CSS.
-      */
       const setLineStyle = ( newStyle ) => {
          let newClasses = cleanExistingLineClasses(existingClasses);
 
@@ -91,51 +92,49 @@ const withHeadlineLineControl = createHigherOrderComponent( ( BlockEdit ) => {
          setAttributes( { className: newClasses } );
       };
 
-      /**
-      * Maneja el cambio del ToggleControl para el marquee y actualiza las clases CSS.
-      */
       const setMarqueeEnabled = ( enabled ) => {
          let newClasses = cleanMarqueeClass(existingClasses);
-         const updatedHtmlAttributes = { ...htmlAttributes };
          const newAttributes = { className: newClasses };
 
          if ( enabled ) {
             newClasses = ( newClasses + ' ' + MARQUEE_CLASS ).trim();
             newAttributes.className = newClasses;
-            // Set default speed if not already set
-            if ( !attributes[MARQUEE_SPEED_ATTR] ) {
-               newAttributes[MARQUEE_SPEED_ATTR] = 'medium';
-               updatedHtmlAttributes['data-marquee-speed'] = MARQUEE_SPEEDS.medium;
-            } else {
-               const speedValue = MARQUEE_SPEEDS[attributes[MARQUEE_SPEED_ATTR]] || MARQUEE_SPEEDS.medium;
-               updatedHtmlAttributes['data-marquee-speed'] = speedValue;
+            const currentSpeed = attributes[MARQUEE_SPEED_ATTR] || 'medium';
+            newAttributes[MARQUEE_SPEED_ATTR] = currentSpeed;
+
+            // GB blocks store speed in htmlAttributes for direct rendering.
+            if ( isGBBlock ) {
+               const updatedHtmlAttributes = { ...htmlAttributes };
+               updatedHtmlAttributes['data-marquee-speed'] = MARQUEE_SPEEDS[currentSpeed] || MARQUEE_SPEEDS.medium;
+               newAttributes.htmlAttributes = updatedHtmlAttributes;
             }
-            newAttributes.htmlAttributes = updatedHtmlAttributes;
          } else {
-            // Remove speed attribute when disabling
-            newAttributes[MARQUEE_SPEED_ATTR] = undefined;
-            delete updatedHtmlAttributes['data-marquee-speed'];
-            newAttributes.htmlAttributes = updatedHtmlAttributes;
+            newAttributes[MARQUEE_SPEED_ATTR] = '';
+
+            if ( isGBBlock ) {
+               const updatedHtmlAttributes = { ...htmlAttributes };
+               delete updatedHtmlAttributes['data-marquee-speed'];
+               newAttributes.htmlAttributes = updatedHtmlAttributes;
+            }
          }
 
          setAttributes( newAttributes );
       };
 
-      /**
-      * Maneja el cambio de la velocidad del marquee.
-      */
       const setMarqueeSpeed = ( speedPreset ) => {
          const speedValue = MARQUEE_SPEEDS[speedPreset] || MARQUEE_SPEEDS.medium;
-         const updatedHtmlAttributes = { ...htmlAttributes };
-         updatedHtmlAttributes['data-marquee-speed'] = speedValue;
-         setAttributes( { 
-            [MARQUEE_SPEED_ATTR]: speedPreset,
-            htmlAttributes: updatedHtmlAttributes
-         } );
-         
-         // Update marquee wrapper directly if it exists (for immediate preview)
+         const newAttributes = { [MARQUEE_SPEED_ATTR]: speedPreset };
+
+         if ( isGBBlock ) {
+            const updatedHtmlAttributes = { ...htmlAttributes };
+            updatedHtmlAttributes['data-marquee-speed'] = speedValue;
+            newAttributes.htmlAttributes = updatedHtmlAttributes;
+         }
+
+         setAttributes( newAttributes );
+
+         // Update marquee wrapper directly for immediate preview
          setTimeout(function() {
-            // Try to find the marquee wrapper in editor
             const blockElement = document.querySelector('[data-block="' + props.clientId + '"]');
             if (blockElement) {
                const marqueeElement = blockElement.querySelector('.gb-marquee-infinite-scroll');
@@ -169,41 +168,43 @@ const withHeadlineLineControl = createHigherOrderComponent( ( BlockEdit ) => {
             <BlockEdit { ...props } />
 
             <InspectorControls>
-               <PanelBody 
+               <PanelBody
                   title={ __( 'FrontBlocks - Visual Effects', 'frontblocks' ) }
                   initialOpen={ false }
                >
                   <p style={{ marginTop: 0, marginBottom: '10px' }}>
                      <small>{ __( 'FrontBlocks visual effect settings.', 'frontblocks' ) }</small>
                   </p>
-                     
-                  <SelectControl
-                     label={ __( 'Decorative Line Style', 'frontblocks' ) }
-                     value={ currentLineStyle }
-                     options={[
-                        { label: __( 'None', 'frontblocks' ), value: 'none' },
-                        { label: __( 'Vertical Line (Right)', 'frontblocks' ), value: 'vertical' },
-                        { label: __( 'Horizontal Line (Right)', 'frontblocks' ), value: 'horizontal' },
-                     ]}
-                     onChange={ setLineStyle }
-                     help={ 
-                           currentLineStyle === 'none' ? 
-                           __( 'Select a line style to add a decorative element.', 'frontblocks' ) : 
-                           sprintf( 
-                              __( 'Current style: %s.', 'frontblocks' ), 
-                              currentLineStyle.charAt(0).toUpperCase() + currentLineStyle.slice(1) 
-                           )
-                     }
-                  />
+
+                  { isGBBlock && (
+                     <SelectControl
+                        label={ __( 'Decorative Line Style', 'frontblocks' ) }
+                        value={ currentLineStyle }
+                        options={[
+                           { label: __( 'None', 'frontblocks' ), value: 'none' },
+                           { label: __( 'Vertical Line (Right)', 'frontblocks' ), value: 'vertical' },
+                           { label: __( 'Horizontal Line (Right)', 'frontblocks' ), value: 'horizontal' },
+                        ]}
+                        onChange={ setLineStyle }
+                        help={
+                              currentLineStyle === 'none' ?
+                              __( 'Select a line style to add a decorative element.', 'frontblocks' ) :
+                              sprintf(
+                                 __( 'Current style: %s.', 'frontblocks' ),
+                                 currentLineStyle.charAt(0).toUpperCase() + currentLineStyle.slice(1)
+                              )
+                        }
+                     />
+                  )}
 
                   <ToggleControl
                      label={ __( 'Infinite Scrolling Marquee', 'frontblocks' ) }
                      checked={ isMarqueeEnabled }
                      onChange={ setMarqueeEnabled }
-                     help={ 
-                        isMarqueeEnabled ? 
-                        __( 'Marquee effect is active. Text will scroll infinitely.', 'frontblocks' ) : 
-                        __( 'Enable infinite scrolling marquee effect for the headline text.', 'frontblocks' )
+                     help={
+                        isMarqueeEnabled ?
+                        __( 'Marquee effect is active. Text will scroll infinitely.', 'frontblocks' ) :
+                        __( 'Enable infinite scrolling marquee effect for the text.', 'frontblocks' )
                      }
                   />
 
@@ -221,7 +222,7 @@ const withHeadlineLineControl = createHigherOrderComponent( ( BlockEdit ) => {
                      />
                   )}
                </PanelBody>
-               
+
             </InspectorControls>
          </Fragment>
       );

--- a/assets/headline/frontblocks-headline.js
+++ b/assets/headline/frontblocks-headline.js
@@ -19,7 +19,9 @@ var _wp$i18n = wp.i18n,
 var LINE_CLASS_PREFIX = 'gb-line-effect-';
 var MARQUEE_CLASS = 'gb-marquee-infinite-scroll';
 var MARQUEE_SPEED_ATTR = 'frblMarqueeSpeed';
-var BLOCK_NAME = 'generateblocks/text';
+var GB_BLOCK = 'generateblocks/text';
+var NATIVE_BLOCKS = ['core/paragraph', 'core/heading'];
+var ALL_MARQUEE_BLOCKS = [GB_BLOCK].concat(NATIVE_BLOCKS);
 
 // Marquee speed presets
 var MARQUEE_SPEEDS = {
@@ -30,19 +32,19 @@ var MARQUEE_SPEEDS = {
   slow: 40 // 40 seconds - slow
 };
 
-// Register marquee speed attribute
+// Register marquee speed attribute for all supported blocks
 wp.hooks.addFilter('blocks.registerBlockType', 'frontblocks/add-marquee-attribute', function (settings, name) {
-  if (name === BLOCK_NAME) {
+  if (ALL_MARQUEE_BLOCKS.includes(name)) {
     settings.attributes = Object.assign(settings.attributes || {}, _defineProperty({}, MARQUEE_SPEED_ATTR, {
       type: 'string',
-      default: 'medium'
+      default: ''
     }));
   }
   return settings;
 });
 var withHeadlineLineControl = createHigherOrderComponent(function (BlockEdit) {
   return function (props) {
-    if (props.name !== BLOCK_NAME) {
+    if (!ALL_MARQUEE_BLOCKS.includes(props.name)) {
       return /*#__PURE__*/React.createElement(BlockEdit, props);
     }
     var attributes = props.attributes,
@@ -50,6 +52,7 @@ var withHeadlineLineControl = createHigherOrderComponent(function (BlockEdit) {
     var existingClasses = attributes.className || '';
     var htmlAttributes = attributes.htmlAttributes || {};
     var marqueeSpeed = attributes[MARQUEE_SPEED_ATTR] || 'medium';
+    var isGBBlock = props.name === GB_BLOCK;
     var cleanExistingLineClasses = function cleanExistingLineClasses(classes) {
       return classes.split(' ').filter(function (cls) {
         return !cls.startsWith(LINE_CLASS_PREFIX);
@@ -61,16 +64,14 @@ var withHeadlineLineControl = createHigherOrderComponent(function (BlockEdit) {
       }).join(' ').replace(/\s{2,}/g, ' ').trim();
     };
     var currentLineStyle = 'none';
-    if (existingClasses.includes(LINE_CLASS_PREFIX + 'vertical')) {
-      currentLineStyle = 'vertical';
-    } else if (existingClasses.includes(LINE_CLASS_PREFIX + 'horizontal')) {
-      currentLineStyle = 'horizontal';
+    if (isGBBlock) {
+      if (existingClasses.includes(LINE_CLASS_PREFIX + 'vertical')) {
+        currentLineStyle = 'vertical';
+      } else if (existingClasses.includes(LINE_CLASS_PREFIX + 'horizontal')) {
+        currentLineStyle = 'horizontal';
+      }
     }
     var isMarqueeEnabled = existingClasses.includes(MARQUEE_CLASS);
-
-    /**
-    * Maneja el cambio del SelectControl y actualiza las clases CSS.
-    */
     var setLineStyle = function setLineStyle(newStyle) {
       var newClasses = cleanExistingLineClasses(existingClasses);
       if (newStyle !== 'none') {
@@ -86,49 +87,45 @@ var withHeadlineLineControl = createHigherOrderComponent(function (BlockEdit) {
         className: newClasses
       });
     };
-
-    /**
-    * Maneja el cambio del ToggleControl para el marquee y actualiza las clases CSS.
-    */
     var setMarqueeEnabled = function setMarqueeEnabled(enabled) {
       var newClasses = cleanMarqueeClass(existingClasses);
-      var updatedHtmlAttributes = _objectSpread({}, htmlAttributes);
       var newAttributes = {
         className: newClasses
       };
       if (enabled) {
         newClasses = (newClasses + ' ' + MARQUEE_CLASS).trim();
         newAttributes.className = newClasses;
-        // Set default speed if not already set
-        if (!attributes[MARQUEE_SPEED_ATTR]) {
-          newAttributes[MARQUEE_SPEED_ATTR] = 'medium';
-          updatedHtmlAttributes['data-marquee-speed'] = MARQUEE_SPEEDS.medium;
-        } else {
-          var speedValue = MARQUEE_SPEEDS[attributes[MARQUEE_SPEED_ATTR]] || MARQUEE_SPEEDS.medium;
-          updatedHtmlAttributes['data-marquee-speed'] = speedValue;
+        var currentSpeed = attributes[MARQUEE_SPEED_ATTR] || 'medium';
+        newAttributes[MARQUEE_SPEED_ATTR] = currentSpeed;
+
+        // GB blocks store speed in htmlAttributes for direct rendering.
+        if (isGBBlock) {
+          var updatedHtmlAttributes = _objectSpread({}, htmlAttributes);
+          updatedHtmlAttributes['data-marquee-speed'] = MARQUEE_SPEEDS[currentSpeed] || MARQUEE_SPEEDS.medium;
+          newAttributes.htmlAttributes = updatedHtmlAttributes;
         }
-        newAttributes.htmlAttributes = updatedHtmlAttributes;
       } else {
-        // Remove speed attribute when disabling
-        newAttributes[MARQUEE_SPEED_ATTR] = undefined;
-        delete updatedHtmlAttributes['data-marquee-speed'];
-        newAttributes.htmlAttributes = updatedHtmlAttributes;
+        newAttributes[MARQUEE_SPEED_ATTR] = '';
+        if (isGBBlock) {
+          var _updatedHtmlAttributes = _objectSpread({}, htmlAttributes);
+          delete _updatedHtmlAttributes['data-marquee-speed'];
+          newAttributes.htmlAttributes = _updatedHtmlAttributes;
+        }
       }
       setAttributes(newAttributes);
     };
-
-    /**
-    * Maneja el cambio de la velocidad del marquee.
-    */
     var setMarqueeSpeed = function setMarqueeSpeed(speedPreset) {
       var speedValue = MARQUEE_SPEEDS[speedPreset] || MARQUEE_SPEEDS.medium;
-      var updatedHtmlAttributes = _objectSpread({}, htmlAttributes);
-      updatedHtmlAttributes['data-marquee-speed'] = speedValue;
-      setAttributes(_defineProperty(_defineProperty({}, MARQUEE_SPEED_ATTR, speedPreset), "htmlAttributes", updatedHtmlAttributes));
+      var newAttributes = _defineProperty({}, MARQUEE_SPEED_ATTR, speedPreset);
+      if (isGBBlock) {
+        var updatedHtmlAttributes = _objectSpread({}, htmlAttributes);
+        updatedHtmlAttributes['data-marquee-speed'] = speedValue;
+        newAttributes.htmlAttributes = updatedHtmlAttributes;
+      }
+      setAttributes(newAttributes);
 
-      // Update marquee wrapper directly if it exists (for immediate preview)
+      // Update marquee wrapper directly for immediate preview
       setTimeout(function () {
-        // Try to find the marquee wrapper in editor
         var blockElement = document.querySelector('[data-block="' + props.clientId + '"]');
         if (blockElement) {
           var marqueeElement = blockElement.querySelector('.gb-marquee-infinite-scroll');
@@ -163,7 +160,7 @@ var withHeadlineLineControl = createHigherOrderComponent(function (BlockEdit) {
         marginTop: 0,
         marginBottom: '10px'
       }
-    }, /*#__PURE__*/React.createElement("small", null, __('FrontBlocks visual effect settings.', 'frontblocks'))), /*#__PURE__*/React.createElement(SelectControl, {
+    }, /*#__PURE__*/React.createElement("small", null, __('FrontBlocks visual effect settings.', 'frontblocks'))), isGBBlock && /*#__PURE__*/React.createElement(SelectControl, {
       label: __('Decorative Line Style', 'frontblocks'),
       value: currentLineStyle,
       options: [{
@@ -182,7 +179,7 @@ var withHeadlineLineControl = createHigherOrderComponent(function (BlockEdit) {
       label: __('Infinite Scrolling Marquee', 'frontblocks'),
       checked: isMarqueeEnabled,
       onChange: setMarqueeEnabled,
-      help: isMarqueeEnabled ? __('Marquee effect is active. Text will scroll infinitely.', 'frontblocks') : __('Enable infinite scrolling marquee effect for the headline text.', 'frontblocks')
+      help: isMarqueeEnabled ? __('Marquee effect is active. Text will scroll infinitely.', 'frontblocks') : __('Enable infinite scrolling marquee effect for the text.', 'frontblocks')
     }), isMarqueeEnabled && /*#__PURE__*/React.createElement(SelectControl, {
       label: __('Marquee Speed', 'frontblocks'),
       value: marqueeSpeed,

--- a/includes/Frontend/Headline.php
+++ b/includes/Frontend/Headline.php
@@ -28,6 +28,9 @@ class Headline {
 		add_filter( 'generateblocks_attr_text', array( $this, 'add_marquee_speed_attribute' ), 10, 2 );
 		add_filter( 'render_block_generateblocks/text', array( $this, 'maybe_enqueue_frontend_assets' ), 10, 2 );
 		add_filter( 'render_block_generateblocks/headline', array( $this, 'maybe_enqueue_frontend_assets' ), 10, 2 );
+		add_filter( 'register_block_type_args', array( $this, 'register_native_block_attributes' ), 10, 2 );
+		add_filter( 'render_block_core/paragraph', array( $this, 'apply_marquee_to_native_block' ), 10, 2 );
+		add_filter( 'render_block_core/heading', array( $this, 'apply_marquee_to_native_block' ), 10, 2 );
 	}
 
 	/**
@@ -117,6 +120,73 @@ class Headline {
 	 */
 	public function add_line_class_attribute( $attributes ) {
 		return $attributes;
+	}
+
+	/**
+	 * Register frblMarqueeSpeed attribute server-side for paragraph and heading.
+	 *
+	 * @param array  $args       Block type args.
+	 * @param string $block_type Block type name.
+	 * @return array
+	 */
+	public function register_native_block_attributes( $args, $block_type ) {
+		if ( 'core/paragraph' !== $block_type && 'core/heading' !== $block_type ) {
+			return $args;
+		}
+
+		if ( ! isset( $args['attributes'] ) ) {
+			$args['attributes'] = array();
+		}
+
+		$args['attributes']['frblMarqueeSpeed'] = array(
+			'type'    => 'string',
+			'default' => '',
+		);
+
+		return $args;
+	}
+
+	/**
+	 * Inject data-marquee-speed and enqueue scripts for native paragraph/heading blocks.
+	 *
+	 * @param string $block_content Block HTML.
+	 * @param array  $block         Block data.
+	 * @return string
+	 */
+	public function apply_marquee_to_native_block( $block_content, $block ) {
+		$attrs      = $block['attrs'] ?? array();
+		$class_name = $attrs['className'] ?? '';
+
+		if ( false === strpos( $class_name, 'gb-marquee-infinite-scroll' ) ) {
+			return $block_content;
+		}
+
+		$speed_presets = array(
+			'fast'   => 10,
+			'medium' => 20,
+			'slow'   => 40,
+		);
+
+		$speed       = isset( $attrs['frblMarqueeSpeed'] ) && ! empty( $attrs['frblMarqueeSpeed'] ) ? sanitize_text_field( $attrs['frblMarqueeSpeed'] ) : 'medium';
+		$speed_value = isset( $speed_presets[ $speed ] ) ? $speed_presets[ $speed ] : 20;
+
+		// Inject data-marquee-speed into the first opening tag.
+		$block_content = preg_replace(
+			'/(<[a-z][a-z0-9]*(?:\s[^>]*)?)(\s*>)/i',
+			'$1 data-marquee-speed="' . esc_attr( $speed_value ) . '"$2',
+			$block_content,
+			1
+		);
+
+		if ( ! wp_script_is( 'frontblocks-headline-marquee', 'enqueued' ) ) {
+			wp_enqueue_script( 'frontblocks-headline-marquee' );
+		}
+
+		if ( ! wp_style_is( 'frontblocks-headline-styles', 'enqueued' ) ) {
+			wp_enqueue_style( 'frontblocks-headline-styles' );
+		}
+
+		return $block_content;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Extends the infinite scrolling marquee effect to native `core/paragraph` and `core/heading` blocks, previously only available on `generateblocks/text`.

## Changes

- **JSX editor panel** (`frontblocks-headline-option.jsx`): Added `NATIVE_BLOCKS = ['core/paragraph', 'core/heading']` and combined into `ALL_MARQUEE_BLOCKS`. Added `isGBBlock` flag to conditionally show the Decorative Line Style control (GenerateBlocks only). HTML attributes update logic guarded with `isGBBlock` since native blocks do not use the `htmlAttributes` attribute. Changed `frblMarqueeSpeed` default from `'medium'` to `''`.
- **PHP render** (`Headline.php`): Added `register_native_block_attributes()` via `register_block_type_args` to register marquee attributes on `core/paragraph` and `core/heading`. Added `apply_marquee_to_native_block()` which checks for the `gb-marquee-infinite-scroll` class, injects `data-marquee-speed` via `preg_replace`, and enqueues scripts on demand. Hooked to `render_block_core/paragraph` and `render_block_core/heading`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Fpost-new.php%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Ffrontblocks%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-181-8c15f89755414a8493f89dc838ff57ac5e8fa5a0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22generateblocks%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->