### PR TITLE
Add container edge alignment in Native Blocks

### DIFF
--- a/assets/container-edge-alignment/frontblocks-edge-alignment-option.jsx
+++ b/assets/container-edge-alignment/frontblocks-edge-alignment-option.jsx
@@ -5,25 +5,24 @@ const { InspectorControls } = wp.blockEditor;
 const { PanelBody, SelectControl } = wp.components;
 const { __ } = wp.i18n;
 
+const GB_BLOCKS    = [ 'generateblocks/container', 'generateblocks/element' ];
+const NATIVE_BLOCKS = [ 'core/group', 'core/columns' ];
+const ALL_SUPPORTED_BLOCKS = [ ...GB_BLOCKS, ...NATIVE_BLOCKS ];
+
 /**
- * Add custom attributes to GenerateBlocks Container block.
- *
- * @param {Object} settings Block settings.
- * @param {string} name Block name.
- * @return {Object} Modified settings.
+ * Add custom attributes to supported blocks.
  */
-function addEdgeAlignmentAttributes(settings, name) {
-	// Support both old (container) and new (element) GenerateBlocks versions
-	if (name !== 'generateblocks/container' && name !== 'generateblocks/element') {
+function addEdgeAlignmentAttributes( settings, name ) {
+	if ( ! ALL_SUPPORTED_BLOCKS.includes( name ) ) {
 		return settings;
 	}
 
-	settings.attributes = Object.assign(settings.attributes, {
+	settings.attributes = Object.assign( settings.attributes, {
 		frblEdgeAlignment: {
 			type: 'string',
 			default: '',
 		},
-	});
+	} );
 
 	return settings;
 }
@@ -35,97 +34,109 @@ addFilter(
 );
 
 /**
- * Check if container uses GenerateBlocks global container width.
+ * Check if a GenerateBlocks container uses the global container width.
  * Only containers with var(--gb-container-width) should have edge alignment.
- *
- * @param {Object} attributes Block attributes.
- * @return {boolean} True if uses global container width.
  */
-function usesGlobalMaxWidth(attributes) {
-	// GenerateBlocks stores styles in an object (not array).
-	// Check if maxWidth uses var(--gb-container-width) and margins are auto.
-	if (!attributes.styles || typeof attributes.styles !== 'object') {
+function usesGlobalMaxWidth( attributes ) {
+	if ( ! attributes.styles || typeof attributes.styles !== 'object' ) {
 		return false;
 	}
-	
-	// Check if maxWidth contains the global container width variable.
-	if (attributes.styles.maxWidth && 
-	    attributes.styles.maxWidth.includes('var(--gb-container-width)')) {
-		// Also verify it's centered (marginLeft and marginRight are auto).
-		if (attributes.styles.marginLeft === 'auto' && 
-		    attributes.styles.marginRight === 'auto') {
+
+	if (
+		attributes.styles.maxWidth &&
+		attributes.styles.maxWidth.includes( 'var(--gb-container-width)' )
+	) {
+		if (
+			attributes.styles.marginLeft === 'auto' &&
+			attributes.styles.marginRight === 'auto'
+		) {
 			return true;
 		}
 	}
-	
+
 	return false;
 }
 
 /**
- * Add edge alignment controls to GenerateBlocks Container block inspector.
- * ONLY shows if container uses GeneratePress global max-width.
+ * Check if a native block uses a constrained (centered, max-width) layout.
+ * Matches core/group and core/columns with constrained layout or inherited layout.
  */
-const withEdgeAlignmentControls = createHigherOrderComponent((BlockEdit) => {
-	return (props) => {
-		// Support both old (container) and new (element) GenerateBlocks versions
-		if (props.name !== 'generateblocks/container' && props.name !== 'generateblocks/element') {
-			return <BlockEdit {...props} />;
+function usesConstrainedLayout( attributes ) {
+	// No explicit layout — inherits from theme, which is typically constrained.
+	if ( ! attributes.layout ) {
+		return true;
+	}
+	return attributes.layout.type === 'constrained';
+}
+
+/**
+ * Add edge alignment controls to supported block inspector panels.
+ */
+const withEdgeAlignmentControls = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		if ( ! ALL_SUPPORTED_BLOCKS.includes( props.name ) ) {
+			return <BlockEdit { ...props } />;
 		}
 
 		const { attributes, setAttributes } = props;
 		const { frblEdgeAlignment } = attributes;
-		
-		// Only show panel if container uses centered layout (margin auto).
-		if (!usesGlobalMaxWidth(attributes)) {
-			return <BlockEdit {...props} />;
+		const isGBBlock = GB_BLOCKS.includes( props.name );
+
+		// Guard: only show panel when the block uses a centered/constrained layout.
+		const shouldShowPanel = isGBBlock
+			? usesGlobalMaxWidth( attributes )
+			: usesConstrainedLayout( attributes );
+
+		if ( ! shouldShowPanel ) {
+			return <BlockEdit { ...props } />;
 		}
 
 		return (
 			<Fragment>
-				<BlockEdit {...props} />
+				<BlockEdit { ...props } />
 				<InspectorControls>
 					<PanelBody
-						title={__('FrontBlocks Edge Alignment', 'frontblocks')}
-						initialOpen={false}
+						title={ __( 'FrontBlocks Edge Alignment', 'frontblocks' ) }
+						initialOpen={ false }
 						className="frbl-edge-alignment-panel"
 					>
 						<p className="frbl-edge-alignment-description">
-							{__(
+							{ __(
 								'Remove padding from one side to create an edge-to-edge effect. Perfect for asymmetric layouts where content extends to the browser edge on one side.',
 								'frontblocks'
-							)}
+							) }
 						</p>
 						<SelectControl
-							label={__('Align to Edge', 'frontblocks')}
-							value={frblEdgeAlignment}
-							options={[
+							label={ __( 'Align to Edge', 'frontblocks' ) }
+							value={ frblEdgeAlignment }
+							options={ [
 								{
-									label: __('None', 'frontblocks'),
+									label: __( 'None', 'frontblocks' ),
 									value: '',
 								},
 								{
-									label: __('Remove Left Padding', 'frontblocks'),
+									label: __( 'Remove Left Padding', 'frontblocks' ),
 									value: 'left',
 								},
 								{
-									label: __('Remove Right Padding', 'frontblocks'),
+									label: __( 'Remove Right Padding', 'frontblocks' ),
 									value: 'right',
 								},
-							]}
-							onChange={(value) =>
-								setAttributes({ frblEdgeAlignment: value })
+							] }
+							onChange={ ( value ) =>
+								setAttributes( { frblEdgeAlignment: value } )
 							}
-							help={__(
+							help={ __(
 								'Choose which side should extend to the browser edge.',
 								'frontblocks'
-							)}
+							) }
 						/>
 					</PanelBody>
 				</InspectorControls>
 			</Fragment>
 		);
 	};
-}, 'withEdgeAlignmentControls');
+}, 'withEdgeAlignmentControls' );
 
 addFilter(
 	'editor.BlockEdit',
@@ -134,13 +145,12 @@ addFilter(
 );
 
 /**
- * Add custom classes to block in editor for visual feedback.
+ * Add visual feedback classes in the editor.
  */
-const addEdgeAlignmentClass = createHigherOrderComponent((BlockListBlock) => {
-	return (props) => {
-		// Support both old (container) and new (element) GenerateBlocks versions
-		if (props.name !== 'generateblocks/container' && props.name !== 'generateblocks/element') {
-			return <BlockListBlock {...props} />;
+const addEdgeAlignmentClass = createHigherOrderComponent( ( BlockListBlock ) => {
+	return ( props ) => {
+		if ( ! ALL_SUPPORTED_BLOCKS.includes( props.name ) ) {
+			return <BlockListBlock { ...props } />;
 		}
 
 		const { attributes } = props;
@@ -148,28 +158,27 @@ const addEdgeAlignmentClass = createHigherOrderComponent((BlockListBlock) => {
 
 		let additionalClasses = '';
 
-		if (frblEdgeAlignment === 'left') {
+		if ( frblEdgeAlignment === 'left' ) {
 			additionalClasses = ' frbl-edge-left';
-		} else if (frblEdgeAlignment === 'right') {
+		} else if ( frblEdgeAlignment === 'right' ) {
 			additionalClasses = ' frbl-edge-right';
 		}
 
-		if (additionalClasses) {
+		if ( additionalClasses ) {
 			return (
 				<BlockListBlock
-					{...props}
-					className={props.className + additionalClasses}
+					{ ...props }
+					className={ props.className + additionalClasses }
 				/>
 			);
 		}
 
-		return <BlockListBlock {...props} />;
+		return <BlockListBlock { ...props } />;
 	};
-}, 'addEdgeAlignmentClass');
+}, 'addEdgeAlignmentClass' );
 
 addFilter(
 	'editor.BlockListBlock',
 	'frontblocks/edge-alignment-class',
 	addEdgeAlignmentClass
 );
-

--- a/assets/container-edge-alignment/frontblocks-edge-alignment.css
+++ b/assets/container-edge-alignment/frontblocks-edge-alignment.css
@@ -91,7 +91,7 @@
 	padding-right: 0 !important;
 }
 
-/* Ensure child elements respect the edge alignment */
+/* Ensure child elements respect the edge alignment — GenerateBlocks */
 .frbl-edge-left > .gb-container,
 .frbl-edge-left > .gb-grid-wrapper,
 .frbl-edge-left > .gb-inside-container {
@@ -102,6 +102,19 @@
 .frbl-edge-right > .gb-container,
 .frbl-edge-right > .gb-grid-wrapper,
 .frbl-edge-right > .gb-inside-container {
+	padding-right: 0 !important;
+	margin-right: 0 !important;
+}
+
+/* Ensure child elements respect the edge alignment — native core blocks */
+.frbl-edge-left > .wp-block-group__inner-container,
+.frbl-edge-left > .wp-block-columns {
+	padding-left: 0 !important;
+	margin-left: 0 !important;
+}
+
+.frbl-edge-right > .wp-block-group__inner-container,
+.frbl-edge-right > .wp-block-columns {
 	padding-right: 0 !important;
 	margin-right: 0 !important;
 }

--- a/assets/container-edge-alignment/frontblocks-edge-alignment.js
+++ b/assets/container-edge-alignment/frontblocks-edge-alignment.js
@@ -10,17 +10,15 @@ var _wp$components = wp.components,
   PanelBody = _wp$components.PanelBody,
   SelectControl = _wp$components.SelectControl;
 var __ = wp.i18n.__;
+var GB_BLOCKS = ['generateblocks/container', 'generateblocks/element'];
+var NATIVE_BLOCKS = ['core/group', 'core/columns'];
+var ALL_SUPPORTED_BLOCKS = [].concat(GB_BLOCKS, NATIVE_BLOCKS);
 
 /**
- * Add custom attributes to GenerateBlocks Container block.
- *
- * @param {Object} settings Block settings.
- * @param {string} name Block name.
- * @return {Object} Modified settings.
+ * Add custom attributes to supported blocks.
  */
 function addEdgeAlignmentAttributes(settings, name) {
-  // Support both old (container) and new (element) GenerateBlocks versions
-  if (name !== 'generateblocks/container' && name !== 'generateblocks/element') {
+  if (!ALL_SUPPORTED_BLOCKS.includes(name)) {
     return settings;
   }
   settings.attributes = Object.assign(settings.attributes, {
@@ -34,22 +32,14 @@ function addEdgeAlignmentAttributes(settings, name) {
 addFilter('blocks.registerBlockType', 'frontblocks/edge-alignment-attributes', addEdgeAlignmentAttributes);
 
 /**
- * Check if container uses GenerateBlocks global container width.
+ * Check if a GenerateBlocks container uses the global container width.
  * Only containers with var(--gb-container-width) should have edge alignment.
- *
- * @param {Object} attributes Block attributes.
- * @return {boolean} True if uses global container width.
  */
 function usesGlobalMaxWidth(attributes) {
-  // GenerateBlocks stores styles in an object (not array).
-  // Check if maxWidth uses var(--gb-container-width) and margins are auto.
   if (!attributes.styles || _typeof(attributes.styles) !== 'object') {
     return false;
   }
-
-  // Check if maxWidth contains the global container width variable.
   if (attributes.styles.maxWidth && attributes.styles.maxWidth.includes('var(--gb-container-width)')) {
-    // Also verify it's centered (marginLeft and marginRight are auto).
     if (attributes.styles.marginLeft === 'auto' && attributes.styles.marginRight === 'auto') {
       return true;
     }
@@ -58,21 +48,33 @@ function usesGlobalMaxWidth(attributes) {
 }
 
 /**
- * Add edge alignment controls to GenerateBlocks Container block inspector.
- * ONLY shows if container uses GeneratePress global max-width.
+ * Check if a native block uses a constrained (centered, max-width) layout.
+ * Matches core/group and core/columns with constrained layout or inherited layout.
+ */
+function usesConstrainedLayout(attributes) {
+  // No explicit layout — inherits from theme, which is typically constrained.
+  if (!attributes.layout) {
+    return true;
+  }
+  return attributes.layout.type === 'constrained';
+}
+
+/**
+ * Add edge alignment controls to supported block inspector panels.
  */
 var withEdgeAlignmentControls = createHigherOrderComponent(function (BlockEdit) {
   return function (props) {
-    // Support both old (container) and new (element) GenerateBlocks versions
-    if (props.name !== 'generateblocks/container' && props.name !== 'generateblocks/element') {
+    if (!ALL_SUPPORTED_BLOCKS.includes(props.name)) {
       return /*#__PURE__*/React.createElement(BlockEdit, props);
     }
     var attributes = props.attributes,
       setAttributes = props.setAttributes;
     var frblEdgeAlignment = attributes.frblEdgeAlignment;
+    var isGBBlock = GB_BLOCKS.includes(props.name);
 
-    // Only show panel if container uses centered layout (margin auto).
-    if (!usesGlobalMaxWidth(attributes)) {
+    // Guard: only show panel when the block uses a centered/constrained layout.
+    var shouldShowPanel = isGBBlock ? usesGlobalMaxWidth(attributes) : usesConstrainedLayout(attributes);
+    if (!shouldShowPanel) {
       return /*#__PURE__*/React.createElement(BlockEdit, props);
     }
     return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(BlockEdit, props), /*#__PURE__*/React.createElement(InspectorControls, null, /*#__PURE__*/React.createElement(PanelBody, {
@@ -106,12 +108,11 @@ var withEdgeAlignmentControls = createHigherOrderComponent(function (BlockEdit) 
 addFilter('editor.BlockEdit', 'frontblocks/edge-alignment-controls', withEdgeAlignmentControls);
 
 /**
- * Add custom classes to block in editor for visual feedback.
+ * Add visual feedback classes in the editor.
  */
 var addEdgeAlignmentClass = createHigherOrderComponent(function (BlockListBlock) {
   return function (props) {
-    // Support both old (container) and new (element) GenerateBlocks versions
-    if (props.name !== 'generateblocks/container' && props.name !== 'generateblocks/element') {
+    if (!ALL_SUPPORTED_BLOCKS.includes(props.name)) {
       return /*#__PURE__*/React.createElement(BlockListBlock, props);
     }
     var attributes = props.attributes;

--- a/includes/Frontend/ContainerEdgeAlignment.php
+++ b/includes/Frontend/ContainerEdgeAlignment.php
@@ -28,6 +28,7 @@ class ContainerEdgeAlignment {
 		add_action( 'init', array( $this, 'register_frontend_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
 		add_filter( 'render_block', array( $this, 'add_edge_alignment_classes' ), 10, 2 );
+		add_filter( 'register_block_type_args', array( $this, 'register_native_block_attributes' ), 10, 2 );
 	}
 
 	/**
@@ -81,6 +82,31 @@ class ContainerEdgeAlignment {
 	}
 
 	/**
+	 * Register frblEdgeAlignment attribute server-side for native blocks.
+	 *
+	 * @param array  $args       Block type args.
+	 * @param string $block_type Block type name.
+	 * @return array
+	 */
+	public function register_native_block_attributes( $args, $block_type ) {
+		$native_blocks = array( 'core/group', 'core/columns' );
+		if ( ! in_array( $block_type, $native_blocks, true ) ) {
+			return $args;
+		}
+
+		if ( ! isset( $args['attributes'] ) ) {
+			$args['attributes'] = array();
+		}
+
+		$args['attributes']['frblEdgeAlignment'] = array(
+			'type'    => 'string',
+			'default' => '',
+		);
+
+		return $args;
+	}
+
+	/**
 	 * Add edge alignment classes to blocks.
 	 *
 	 * @param string $block_content Block content.
@@ -88,8 +114,14 @@ class ContainerEdgeAlignment {
 	 * @return string Modified block content.
 	 */
 	public function add_edge_alignment_classes( $block_content, $block ) {
-		// Only process GenerateBlocks container blocks (support both old and new versions).
-		if ( 'generateblocks/container' !== $block['blockName'] && 'generateblocks/element' !== $block['blockName'] ) {
+		$supported_blocks = array(
+			'generateblocks/container',
+			'generateblocks/element',
+			'core/group',
+			'core/columns',
+		);
+
+		if ( ! in_array( $block['blockName'], $supported_blocks, true ) ) {
 			return $block_content;
 		}
 


### PR DESCRIPTION
## Summary

Extends the Container Edge Alignment feature to native WordPress blocks (`core/group` and `core/columns`), previously only supported on `generateblocks/container`.

## Changes

- **JSX editor panel** (`frontblocks-edge-alignment-option.jsx`): Added `NATIVE_BLOCKS` array with `core/group` and `core/columns`; combined into `ALL_SUPPORTED_BLOCKS`. Added `usesConstrainedLayout()` helper that returns `true` when the block uses a constrained/centered layout (no layout set, or `layout.type === 'constrained'`), so the alignment panel only appears for relevant layouts.
- **CSS** (`frontblocks-edge-alignment.css`): Added rules for `.wp-block-group__inner-container` and `.wp-block-columns` under `.frbl-edge-left` and `.frbl-edge-right` to apply correct edge offset on native block wrappers.
- **PHP render** (`ContainerEdgeAlignment.php`): Added `register_native_block_attributes()` via `register_block_type_args` filter to register `frblEdgeAlignment` attribute on `core/group` and `core/columns`. Updated `add_edge_alignment_classes()` to include these blocks in `$supported_blocks`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Fpost-new.php%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Ffrontblocks%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-182-6ef9cdcf5cb034b35ed4a42ef94d5fc4587e188a.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22generateblocks%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->