### PR TITLE
Add shape icon in Native Icon

### DIFF
--- a/assets/shape-animations/frontblocks-shape-animation-option.js
+++ b/assets/shape-animations/frontblocks-shape-animation-option.js
@@ -27,8 +27,8 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
    */
   function addShapeAnimationControls(BlockEdit) {
     return function (props) {
-      // Only add controls to shape blocks.
-      if (props.name !== 'generateblocks/shape') {
+      // Only add controls to shape and icon blocks.
+      if (props.name !== 'generateblocks/shape' && props.name !== 'core/icon') {
         return wp.element.createElement(BlockEdit, props);
       }
       var attributes = props.attributes,
@@ -201,10 +201,11 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
     useRef = _wp$element2.useRef;
   var withShapeAnimationPreview = createHigherOrderComponent(function (BlockListBlock) {
     return function (props) {
-      if (props.name !== 'generateblocks/shape') {
+      if (props.name !== 'generateblocks/shape' && props.name !== 'core/icon') {
         return wp.element.createElement(BlockListBlock, props);
       }
       var attributes = props.attributes;
+      var isIconBlock = props.name === 'core/icon';
       var _attributes$frblCusto3 = attributes.frblCustomSvgAnimationEnabled,
         frblCustomSvgAnimationEnabled = _attributes$frblCusto3 === void 0 ? false : _attributes$frblCusto3,
         _attributes$frblCusto4 = attributes.frblCustomSvgAnimationJson,
@@ -228,11 +229,12 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
               var blockElement = document.querySelector('[data-block="' + props.clientId + '"]');
               if (!blockElement) return;
 
-              // Find or create Lottie container in the Shape block.
+              // Find or create Lottie container in the block.
               var lottieContainer = blockElement.querySelector('.frbl-lottie-preview');
               if (!lottieContainer) {
-                // Find the gb-shape element.
-                var shapeElement = blockElement.querySelector('.gb-shape');
+                // Find the inner element: .gb-shape for generateblocks/shape, .wp-block-icon for core/icon.
+                var containerSelector = isIconBlock ? '.wp-block-icon' : '.gb-shape';
+                var shapeElement = blockElement.querySelector(containerSelector);
                 if (shapeElement) {
                   // HIDE original SVG completely.
                   var originalSvg = shapeElement.querySelector('svg');
@@ -327,7 +329,7 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
             lottieInstanceRef.current = null;
           }
         };
-      }, [frblCustomSvgAnimationEnabled, frblCustomSvgAnimationJson, props.clientId, styles]);
+      }, [frblCustomSvgAnimationEnabled, frblCustomSvgAnimationJson, props.clientId, styles, isIconBlock]);
       return wp.element.createElement(BlockListBlock, props);
     };
   }, 'withShapeAnimationPreview');

--- a/assets/shape-animations/frontblocks-shape-animation-option.jsx
+++ b/assets/shape-animations/frontblocks-shape-animation-option.jsx
@@ -12,8 +12,8 @@
 	 */
 	function addShapeAnimationControls(BlockEdit) {
 		return function(props) {
-			// Only add controls to shape blocks.
-			if (props.name !== 'generateblocks/shape') {
+			// Only add controls to shape and icon blocks.
+			if (props.name !== 'generateblocks/shape' && props.name !== 'core/icon') {
 				return wp.element.createElement(BlockEdit, props);
 			}
 
@@ -219,11 +219,12 @@
 
 	const withShapeAnimationPreview = createHigherOrderComponent(function(BlockListBlock) {
 		return function(props) {
-			if (props.name !== 'generateblocks/shape') {
+			if (props.name !== 'generateblocks/shape' && props.name !== 'core/icon') {
 				return wp.element.createElement(BlockListBlock, props);
 			}
 
 			const { attributes } = props;
+			const isIconBlock = props.name === 'core/icon';
 			const {
 				frblCustomSvgAnimationEnabled = false,
 				frblCustomSvgAnimationJson = '',
@@ -240,22 +241,23 @@
 
 				try {
 					const parsed = JSON.parse(frblCustomSvgAnimationJson);
-					
+
 					// Check if it's Lottie.
 					const isLottie = parsed.v && parsed.fr && parsed.layers;
-					
+
 					if (isLottie && typeof lottie !== 'undefined') {
 						// Wait for DOM to be ready.
 						setTimeout(function() {
 							const blockElement = document.querySelector('[data-block="' + props.clientId + '"]');
 							if (!blockElement) return;
 
-							// Find or create Lottie container in the Shape block.
+							// Find or create Lottie container in the block.
 							let lottieContainer = blockElement.querySelector('.frbl-lottie-preview');
-							
+
 							if (!lottieContainer) {
-								// Find the gb-shape element.
-								const shapeElement = blockElement.querySelector('.gb-shape');
+								// Find the inner element: .gb-shape for generateblocks/shape, .wp-block-icon for core/icon.
+								const containerSelector = isIconBlock ? '.wp-block-icon' : '.gb-shape';
+								const shapeElement = blockElement.querySelector(containerSelector);
 								if (shapeElement) {
 									// HIDE original SVG completely.
 									const originalSvg = shapeElement.querySelector('svg');
@@ -344,7 +346,7 @@
 						lottieInstanceRef.current = null;
 					}
 				};
-			}, [frblCustomSvgAnimationEnabled, frblCustomSvgAnimationJson, props.clientId, styles]);
+			}, [frblCustomSvgAnimationEnabled, frblCustomSvgAnimationJson, props.clientId, styles, isIconBlock]);
 
 			return wp.element.createElement(BlockListBlock, props);
 		};

--- a/assets/shape-animations/frontblocks-shape-animations.css
+++ b/assets/shape-animations/frontblocks-shape-animations.css
@@ -78,13 +78,16 @@
 	display: inline-block;
 }
 
-/* Hide original Shape SVG when Lottie is active (frontend) */
-.frbl-has-lottie-animation .gb-shape > svg {
+/* Hide original SVG when Lottie is active (frontend) */
+.frbl-has-lottie-animation .gb-shape > svg,
+.frbl-has-lottie-animation .wp-block-icon > svg,
+.frbl-has-lottie-animation .wp-block-icon__icon {
 	display: none !important;
 }
 
-/* Hide original Shape SVG when Lottie preview is active (editor) */
-.block-editor-block-list__block .gb-shape:has(.frbl-lottie-preview) > svg {
+/* Hide original SVG when Lottie preview is active (editor) */
+.block-editor-block-list__block .gb-shape:has(.frbl-lottie-preview) > svg,
+.block-editor-block-list__block .wp-block-icon:has(.frbl-lottie-preview) > svg {
 	display: none !important;
 }
 

--- a/includes/Frontend/ShapeAnimations.php
+++ b/includes/Frontend/ShapeAnimations.php
@@ -22,6 +22,13 @@ defined( 'ABSPATH' ) || exit;
 class ShapeAnimations {
 
 	/**
+	 * CSS animation styles queued for wp_footer output.
+	 *
+	 * @var array
+	 */
+	private static $queued_css = array();
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -38,6 +45,7 @@ class ShapeAnimations {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ), 5 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'register_shape_animation_attributes' ), 15 );
 		add_filter( 'render_block', array( $this, 'add_animation_classes_to_shape' ), 10, 2 );
+		add_action( 'wp_footer', array( $this, 'output_queued_styles' ), 5 );
 	}
 
 	/**
@@ -110,7 +118,7 @@ class ShapeAnimations {
 	}
 
 	/**
-	 * Register animation attributes for Shape block.
+	 * Register animation attributes for Shape and Icon blocks.
 	 *
 	 * @return void
 	 */
@@ -122,7 +130,7 @@ class ShapeAnimations {
 				'blocks.registerBlockType',
 				'frontblocks/shape-animation-attributes',
 				function( settings, name ) {
-					if ( 'generateblocks/shape' !== name ) {
+					if ( 'generateblocks/shape' !== name && 'core/icon' !== name ) {
 						return settings;
 					}
 					
@@ -165,7 +173,8 @@ class ShapeAnimations {
 	 * @return string Modified block content.
 	 */
 	public function add_animation_classes_to_shape( $block_content, $block ) {
-		if ( ! isset( $block['blockName'] ) || 'generateblocks/shape' !== $block['blockName'] ) {
+		if ( ! isset( $block['blockName'] ) ||
+			( 'generateblocks/shape' !== $block['blockName'] && 'core/icon' !== $block['blockName'] ) ) {
 			return $block_content;
 		}
 
@@ -201,8 +210,10 @@ class ShapeAnimations {
 		// Detect animation type: Lottie or CSS.
 		$is_lottie = $this->is_lottie_json( $json_data );
 
+		$block_name = $block['blockName'];
+
 		if ( $is_lottie ) {
-			return $this->render_lottie_animation( $block_content, $json_data, $attrs );
+			return $this->render_lottie_animation( $block_content, $json_data, $attrs, $block_name );
 		} else {
 			return $this->render_css_animation( $block_content, $json_data, $attrs );
 		}
@@ -225,9 +236,10 @@ class ShapeAnimations {
 	 * @param string $block_content Original block content.
 	 * @param array  $json_data Lottie JSON data.
 	 * @param array  $attrs Block attributes.
+	 * @param string $block_name Block name.
 	 * @return string Modified block content.
 	 */
-	private function render_lottie_animation( $block_content, $json_data, $attrs ) {
+	private function render_lottie_animation( $block_content, $json_data, $attrs, $block_name = 'generateblocks/shape' ) {
 		// Generate unique ID for this Lottie instance.
 		$unique_id = 'frbl-lottie-' . wp_generate_password( 8, false );
 
@@ -243,13 +255,20 @@ class ShapeAnimations {
 			$speed    = isset( $json_data['animation']['speed'] ) ? (float) $json_data['animation']['speed'] : 1;
 		}
 
-		// Get Shape block styles (width, height, colors from GenerateBlocks).
-		$styles       = isset( $attrs['styles'] ) ? $attrs['styles'] : array();
-		$svg_styles   = isset( $styles['svg'] ) ? $styles['svg'] : array();
-		$width        = isset( $svg_styles['width'] ) ? $svg_styles['width'] : '';
-		$height       = isset( $svg_styles['height'] ) ? $svg_styles['height'] : '';
-		$fill_color   = isset( $svg_styles['fill'] ) ? $svg_styles['fill'] : '';
-		$stroke_color = isset( $svg_styles['color'] ) ? $svg_styles['color'] : '';
+		// Extract size and color based on block type.
+		if ( 'core/icon' === $block_name ) {
+			$icon_width = isset( $attrs['width'] ) ? absint( $attrs['width'] ) : 0;
+			$width      = $icon_width > 0 ? $icon_width . 'px' : '';
+			$height     = $width;
+			$fill_color = isset( $attrs['style']['color']['text'] ) ? sanitize_text_field( $attrs['style']['color']['text'] ) : '';
+		} else {
+			// Get Shape block styles (width, height, colors from GenerateBlocks).
+			$styles     = isset( $attrs['styles'] ) ? $attrs['styles'] : array();
+			$svg_styles = isset( $styles['svg'] ) ? $styles['svg'] : array();
+			$width      = isset( $svg_styles['width'] ) ? $svg_styles['width'] : '';
+			$height     = isset( $svg_styles['height'] ) ? $svg_styles['height'] : '';
+			$fill_color = isset( $svg_styles['fill'] ) ? $svg_styles['fill'] : '';
+		}
 
 		// Build inline styles.
 		$inline_styles  = 'width: ' . ( ! empty( $width ) ? esc_attr( $width ) : '100%' ) . ';';
@@ -309,6 +328,22 @@ class ShapeAnimations {
 	}
 
 	/**
+	 * Output all queued CSS animation keyframes in the footer.
+	 *
+	 * @return void
+	 */
+	public function output_queued_styles() {
+		if ( empty( self::$queued_css ) ) {
+			return;
+		}
+		echo '<style id="frbl-shape-animation-keyframes">';
+		foreach ( self::$queued_css as $css ) {
+			echo $css; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- sanitized in render_css_animation.
+		}
+		echo '</style>';
+	}
+
+	/**
 	 * Render CSS animation (original functionality).
 	 *
 	 * @param string $block_content Original block content.
@@ -320,7 +355,7 @@ class ShapeAnimations {
 		// Extract SVG and animation data.
 		$custom_svg          = isset( $json_data['svg'] ) ? $json_data['svg'] : '';
 		$animation_data      = isset( $json_data['animation'] ) ? $json_data['animation'] : array();
-		$animation_name      = isset( $animation_data['name'] ) ? sanitize_key( $animation_data['name'] ) : 'customAnimation';
+		$animation_name      = isset( $animation_data['name'] ) ? sanitize_text_field( $animation_data['name'] ) : 'customAnimation';
 		$animation_trigger   = isset( $animation_data['trigger'] ) ? sanitize_text_field( $animation_data['trigger'] ) : 'load';
 		$animation_keyframes = isset( $animation_data['keyframes'] ) ? $animation_data['keyframes'] : '';
 		$animation_duration  = isset( $animation_data['duration'] ) ? sanitize_text_field( $animation_data['duration'] ) : '1s';
@@ -330,29 +365,27 @@ class ShapeAnimations {
 		// Generate unique ID for this block's animation.
 		$unique_id = 'frbl-anim-' . md5( $animation_keyframes );
 
-		// Inject custom keyframes and SVG.
-		if ( ! empty( $animation_keyframes ) ) {
-			// Add inline style with keyframes.
-			$inline_style  = '<style>';
-			$inline_style .= esc_html( $animation_keyframes );
-			$inline_style .= ' .frbl-custom-svg-animation.' . esc_attr( $unique_id ) . ' { ';
-			$inline_style .= 'animation-name: ' . esc_attr( $animation_name ) . '; ';
-			$inline_style .= 'animation-duration: ' . esc_attr( $animation_duration ) . '; ';
-			$inline_style .= 'animation-delay: ' . esc_attr( $animation_delay ) . '; ';
-			$inline_style .= 'animation-fill-mode: both; ';
-			$inline_style .= 'animation-timing-function: ease-in-out; ';
+		// Queue CSS keyframes for footer output (avoids inline style tag issues).
+		if ( ! empty( $animation_keyframes ) && ! isset( self::$queued_css[ $unique_id ] ) ) {
+			// Strip HTML tags to prevent injection; CSS does not use < > & characters.
+			$css  = wp_strip_all_tags( $animation_keyframes );
+			$css .= ' .frbl-custom-svg-animation.' . esc_attr( $unique_id ) . ' { ';
+			$css .= 'animation-name: ' . esc_attr( $animation_name ) . '; ';
+			$css .= 'animation-duration: ' . esc_attr( $animation_duration ) . '; ';
+			$css .= 'animation-delay: ' . esc_attr( $animation_delay ) . '; ';
+			$css .= 'animation-fill-mode: both; ';
+			$css .= 'animation-timing-function: ease-in-out; ';
 			if ( $animation_infinite ) {
-				$inline_style .= 'animation-iteration-count: infinite; ';
+				$css .= 'animation-iteration-count: infinite; ';
 			}
-			$inline_style .= '} ';
+			$css .= '} ';
 			if ( 'hover' === $animation_trigger ) {
-				$inline_style .= ' .frbl-custom-svg-animation.' . esc_attr( $unique_id ) . ':hover { ';
-				$inline_style .= 'animation-play-state: running; ';
-				$inline_style .= '} ';
+				$css .= ' .frbl-custom-svg-animation.' . esc_attr( $unique_id ) . ':hover { ';
+				$css .= 'animation-play-state: running; ';
+				$css .= '} ';
 			}
-			$inline_style .= '</style>';
 
-			$block_content = $inline_style . $block_content;
+			self::$queued_css[ $unique_id ] = $css;
 		}
 
 		// Replace SVG content if provided.


### PR DESCRIPTION
## Summary

Extends the Shape Animation feature to support the native `core/icon` block, in addition to the existing `generateblocks/shape` block.

## Changes

- **JSX editor panel** (`frontblocks-shape-animation-option.jsx`): Added `core/icon` to the supported block check; uses `.wp-block-icon` as the target selector instead of `.gb-shape` for icon blocks; updated `useEffect` dependencies accordingly.
- **CSS** (`frontblocks-shape-animations.css`): Added animation rules targeting `.frbl-has-lottie-animation .wp-block-icon > svg` and `.wp-block-icon__icon` to apply Lottie and CSS animations correctly on native icon blocks.
- **PHP render** (`ShapeAnimations.php`): Added a static `$queued_css` array and `output_queued_styles()` hooked to `wp_footer`, so CSS keyframes are output once in the footer instead of injected inline per block. Extended `add_animation_classes_to_shape()` to handle `core/icon`. `render_lottie_animation()` now accepts a `$block_name` parameter and reads size from `$attrs['width']` for icon blocks vs `$attrs['styles']['svg']` for shape blocks.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Fpost-new.php%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Ffrontblocks%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-183-3fda4c17a30dc6e85f16586eca84b61be931cac0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22generateblocks%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->